### PR TITLE
Fixing `getProduct(barcode)` to use correct endpoint 

### DIFF
--- a/main.js
+++ b/main.js
@@ -63,7 +63,7 @@ class OFF {
    * })
    */
   getProduct (barcode) {
-    return request(`${this.URL}/api/v0/${barcode}`)
+    return request(`${this.URL}/api/v0/product/${barcode}.json`)
       .then(JSON.parse)
   }
 


### PR DESCRIPTION
Current endpoint for `getProduct` will consistently return Barbecue Sauce as the result, regardless of the barcode. 

For example, this UPC for rice noodles shows up as Barbecue Sauce
https://world.openfoodfacts.org/api/v0/737628064502

And when using the `/product/#.json` endpoint it returns the actual product: 
https://world.openfoodfacts.org/api/v0/product/737628064502.json

[Documentation](https://world.openfoodfacts.org/data) currently suggests the second URL is correct, but not sure if the API is in the process of changing, since it mentions it's unstable.  