### PR TITLE
chore: build during prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "types": "dist/main.d.ts",
   "scripts": {
+    "prepack": "yarn run build",
     "build": "tsc",
     "build:docs": "typedoc src/main.ts",
     "lint": "standard",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,7 @@
     },
     "forceConsistentCasingInFileNames": true,
     "target": "ES2015",
-    "rootDirs": [
-      "src",
-      "src/schemas"
-    ],
+    "rootDir": "./src",
     "module": "CommonJS",
     "lib": [
       "ES2022",
@@ -24,5 +21,6 @@
   "exclude": [
     "node_modules",
     "dist",
+    "test"
   ],
 }


### PR DESCRIPTION
### What
- We need to build the package before publishing it, otherwise it can't be used by vanilla JS.
