### PR TITLE
test: fix mock after openapi-fetch upgrade

### DIFF
--- a/tests/folksonomy.spec.ts
+++ b/tests/folksonomy.spec.ts
@@ -1,5 +1,4 @@
-import { Folksonomy, FolksonomyTag, FolksonomyKey } from "../src/folksonomy";
-import { ApiError } from "../src/error";
+import { Folksonomy, FolksonomyTag } from "../src/folksonomy";
 
 describe("Folksonomy Wrapper", () => {
     let fetchMock: jest.Mock;
@@ -32,6 +31,7 @@ describe("Folksonomy Wrapper", () => {
                 },
             },
             json: async () => data,
+            text: async () => JSON.stringify(data),
             clone: () => ({ json: async () => data }),
         };
     };

--- a/tests/nutripatrol.spec.ts
+++ b/tests/nutripatrol.spec.ts
@@ -1,5 +1,5 @@
-import { Flag, NutriPatrol, Ticket } from "../src/nutripatrol";
 import { NutriPatrolError } from "../src/error";
+import { Flag, NutriPatrol, Ticket } from "../src/nutripatrol";
 
 describe("NutriPatrol Wrapper", () => {
     let fetchMock: jest.Mock;
@@ -32,6 +32,7 @@ describe("NutriPatrol Wrapper", () => {
                 },
             },
             json: async () => data,
+            text: async () => JSON.stringify(data),
             clone: () => ({ json: async () => data }),
         };
     };


### PR DESCRIPTION
### What
There is a missing function in the mock of the fetch response.
This bug appears after the upgrade of the openapi-fetch package