### PR TITLE
chore: update release-please action and configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,13 +1,19 @@
-name: Run release-please
+name: release-please
 on:
   push:
     branches:
       - develop
+
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: simple
+          release-type: node
+          target-branch: develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## dev
-
-## Features
-
 ## 1.0.0 (2022-04-27)
 
 ### Features


### PR DESCRIPTION
### What
The actual `GoogleCloudPlatform/release-please-action@v4` is deprecated.
See https://github.com/google-github-actions/release-please-action

This pull request updates the GitHub Actions, improve configuration to target node during release (like updating package.json version) and cleanup of the `CHANGELOG.md` file.