### PR TITLE
chore: clean unused commands and packages in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "types": "dist/main.d.ts",
   "scripts": {
+    "prepack": "yarn run build",
     "build": "tsc -p tsconfig.build.json",
     "build:docs": "typedoc src/main.ts",
     "commitmsg": "commitlint -quiet=0 --extends=@commitlint/config-conventional -e",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,31 @@
 {
   "name": "openfoodfacts-nodejs",
+  "author": "openfoodfacts",
+  "license": "Apache-2.0",
   "version": "2.0.0",
   "description": "Open Food Facts API NodeJS Wrapper",
+  "keywords": [
+    "OFF",
+    "OpenFoodFacts",
+    "NodeJS",
+    "Wrapper"
+  ],
+  "homepage": "https://github.com/openfoodfacts/openfoodfacts-nodejs#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openfoodfacts/openfoodfacts-nodejs.git"
+  },
+  "bugs": {
+    "url": "https://github.com/openfoodfacts/openfoodfacts-nodejs/issues"
+  },
   "exports": [
     "./dist/main.js"
   ],
   "types": "dist/main.d.ts",
   "scripts": {
-    "prepack": "yarn run build",
     "build": "tsc -p tsconfig.build.json",
     "build:docs": "typedoc src/main.ts",
     "commitmsg": "commitlint -quiet=0 --extends=@commitlint/config-conventional -e",
-    "precommit": "standard `git diff --name-only --staged --relative | grep '.js$'`",
     "api": "yarn run api:folksonomy && yarn run api:prices && yarn run api:robotoff && yarn run api:server:v2",
     "api:server:v2": "openapi-typescript 'https://raw.githubusercontent.com/openfoodfacts/openfoodfacts-server/main/docs/api/ref/api.yml' --output src/schemas/server/v2.ts",
     "api:server:v3": "openapi-typescript 'https://raw.githubusercontent.com/openfoodfacts/openfoodfacts-server/main/docs/api/ref/api-v3.yml' --output src/schemas/server/v3.ts",
@@ -19,39 +33,13 @@
     "api:robotoff": "openapi-typescript https://raw.githubusercontent.com/openfoodfacts/robotoff/main/doc/references/api.yml --output src/schemas/robotoff.ts",
     "api:folksonomy": "openapi-typescript https://api.folksonomy.openfoodfacts.org/openapi.json --output src/schemas/folksonomy.ts",
     "api:nutripatrol": "openapi-typescript https://nutripatrol.openfoodfacts.org/api/openapi.json --output src/schemas/nutripatrol.ts",
-    "check": "yarn run lint && yarn run test",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
-    "fix": "standard --fix",
     "test": "jest",
     "test:coverage": "jest --coverage"
   },
-  "standard": {
-    "env": [
-      "mocha"
-    ],
-    "ignore": [
-      "/docs/**/*.js"
-    ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/openfoodfacts/openfoodfacts-nodejs.git"
-  },
-  "keywords": [
-    "OFF",
-    "OpenFoodFacts",
-    "NodeJS",
-    "Wrapper"
-  ],
-  "author": "openfoodfacts",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/openfoodfacts/openfoodfacts-nodejs/issues"
-  },
-  "homepage": "https://github.com/openfoodfacts/openfoodfacts-nodejs#readme",
   "dependencies": {
     "openapi-fetch": "^0.13.0"
   },
@@ -66,7 +54,6 @@
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",
     "eslint": "^9.13.0",
-    "formdata-node": "^6.0.3",
     "globals": "^15.11.0",
     "jest": "^29.7.0",
     "openapi-typescript": "^6.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,13 +2614,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formdata-node@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "formdata-node@npm:6.0.3"
-  checksum: 10/26ec90f5dd5d5572dceb524b86f42e28b148022e5c50b2af83ee8ad99d56f26157a7b5583ddbf10725e567bba30ad8bf6b6527f17f5e94d64ccaa950d1fe0b5f
-  languageName: node
-  linkType: hard
-
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -4340,7 +4333,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.12.2"
     "@typescript-eslint/parser": "npm:^8.12.2"
     eslint: "npm:^9.13.0"
-    formdata-node: "npm:^6.0.3"
     globals: "npm:^15.11.0"
     jest: "npm:^29.7.0"
     openapi-fetch: "npm:^0.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,13 +2621,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"formdata-node@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "formdata-node@npm:6.0.3"
-  checksum: 10/26ec90f5dd5d5572dceb524b86f42e28b148022e5c50b2af83ee8ad99d56f26157a7b5583ddbf10725e567bba30ad8bf6b6527f17f5e94d64ccaa950d1fe0b5f
-  languageName: node
-  linkType: hard
-
 "fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
@@ -4347,7 +4340,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.12.2"
     "@typescript-eslint/parser": "npm:^8.12.2"
     eslint: "npm:^9.13.0"
-    formdata-node: "npm:^6.0.3"
     globals: "npm:^15.11.0"
     jest: "npm:^29.7.0"
     openapi-fetch: "npm:^0.13.0"


### PR DESCRIPTION
This pull request cleans up scripts and dependencies :
- `prepack` command is the same as `build`
- `standard` package are not in dependencies and then config and command related to it are not useful anymore
- `formdata-node` is not used in the codebase