### PR TITLE
fix: use a string as "exports" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
   "bugs": {
     "url": "https://github.com/openfoodfacts/openfoodfacts-nodejs/issues"
   },
-  "exports": [
-    "./dist/main.js"
-  ],
+  "exports": "./dist/main.js",
   "types": "dist/main.d.ts",
   "scripts": {
     "prepack": "yarn run build",


### PR DESCRIPTION
As per https://nodejs.org/api/packages.html#main-entry-point-export
