### PR TITLE
feat: change `Content-Type` in `robotoff.ts` annotate method to `x-ww…

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -17,6 +17,10 @@ export type Question = {
   value?: string;
 };
 
+type QuestionsResponse =
+  | { status?: "found" | "no_questions"; questions?: Question[] }
+  | undefined;
+
 export class Robotoff {
   /** The fetch function used for every request */
   private readonly fetch: typeof global.fetch;
@@ -54,7 +58,7 @@ export class Robotoff {
         path: { barcode: code },
       },
     });
-    return result.data;
+    return result.data as QuestionsResponse;
   }
 
   async insightDetail(id: string) {

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -2,6 +2,7 @@ import createClient from "openapi-fetch";
 
 import { paths } from "./schemas/robotoff";
 import { USER_AGENT } from "./consts";
+import { formBody } from "./formbody";
 
 type InsightQuery = paths["/insights"]["get"]["parameters"]["query"];
 type InsightResponse =
@@ -28,17 +29,15 @@ export class Robotoff {
   }
 
   async annotate(body: AnnotateBody) {
-    const bodySerializer = (body: AnnotateBody) => {
-      const formBody = new URLSearchParams();
-      for (const [key, value] of Object.entries(body)) {
-        formBody.append(key, value.toString());
-      }
-      return formBody;
+    const stringifyValues = (body: AnnotateBody) => {
+      return Object.fromEntries(
+        Object.entries(body).map(([key, value]) => [key, String(value)]),
+      );
     };
     return this.raw.POST("/insights/annotate", {
       body: body,
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      bodySerializer,
+      bodySerializer: (body) => formBody(stringifyValues(body)),
     });
   }
 

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -17,9 +17,10 @@ export type Question = {
   value?: string;
 };
 
-type QuestionsResponse =
-  | { status?: "found" | "no_questions"; questions?: Question[] }
-  | undefined;
+type QuestionsResponse = {
+  status?: "found" | "no_questions";
+  questions?: Question[];
+};
 
 export class Robotoff {
   /** The fetch function used for every request */
@@ -52,7 +53,7 @@ export class Robotoff {
     });
   }
 
-  async questionsByProductCode(code: number) {
+  async questionsByProductCode(code: number): Promise<QuestionsResponse> {
     const result = await this.raw.GET("/questions/{barcode}", {
       params: {
         path: { barcode: code },

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -28,8 +28,17 @@ export class Robotoff {
   }
 
   async annotate(body: AnnotateBody) {
+    const bodySerializer = (body: AnnotateBody) => {
+      const formBody = new URLSearchParams();
+      for (const [key, value] of Object.entries(body)) {
+        formBody.append(key, value.toString());
+      }
+      return formBody
+    };
     return this.raw.POST("/insights/annotate", {
       body: body,
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      bodySerializer
     });
   }
 

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -10,6 +10,13 @@ type InsightResponse =
 type AnnotateBody =
   paths["/insights/annotate"]["post"]["requestBody"]["content"]["application/x-www-form-urlencoded"];
 
+export type Question = {
+  insight_id: string;
+  question: string;
+  image_url?: string;
+  value?: string;
+};
+
 export class Robotoff {
   /** The fetch function used for every request */
   private readonly fetch: typeof global.fetch;

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -33,12 +33,12 @@ export class Robotoff {
       for (const [key, value] of Object.entries(body)) {
         formBody.append(key, value.toString());
       }
-      return formBody
+      return formBody;
     };
     return this.raw.POST("/insights/annotate", {
       body: body,
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      bodySerializer
+      bodySerializer,
     });
   }
 


### PR DESCRIPTION
### What
The content type must be `application/x-www-form-urlencoded` as evident from testing and the [docs](https://openfoodfacts.github.io/robotoff/references/api/#tag/Insights/paths/~1insights~1annotate/post):
![image](https://github.com/user-attachments/assets/4e43a4af-981a-4fa2-b68c-f517459d3445)

**Note:** I didn't use the `formBody` function from `formbody.ts` because It expects `Record<string, string>` as argument. However the `AnnotateBody` only have one string value but three non-string values. Using the `formBody` function would have required to change the argument to `Record<string, any>`.
```ts
export function formBody(params: Record<string, string>) {
...
```
```ts
type AnnotateBody = {
    insight_id: string;
    annotation: 0 | 1 | -1 | 2;
    update?: 0 | 1;
    data?: Record<string, never>;
}
```

### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/264
