### PR TITLE
feat: add support for custom host in OpenFoodFacts constructor

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -22,23 +22,23 @@ on:
 
   pull_request_target:
     types:
-    - assigned
-    - unassigned
-    - labeled
-    - unlabeled
-    - opened
-    - edited
-    - closed
-    - reopened
-    - synchronize
-    - converted_to_draft
-    - ready_for_review
-    - locked
-    - unlocked
-    - review_requested
-    - review_request_removed
-    - auto_merge_enabled
-    - auto_merge_disabled
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - converted_to_draft
+      - ready_for_review
+      - locked
+      - unlocked
+      - review_requested
+      - review_request_removed
+      - auto_merge_enabled
+      - auto_merge_disabled
 jobs:
   add-to-project:
     name: Add issue to project

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ export * from "./folksonomy";
 export * from "./prices";
 export * from "./nutripatrol";
 
-export type OpenFoodFactsOptions = { country: string };
+export type OpenFoodFactsOptions = { country?: string; host?: string };
 
 /** Wrapper of OFF API */
 export class OpenFoodFacts {
@@ -57,7 +57,10 @@ export class OpenFoodFacts {
     fetch: typeof global.fetch,
     options: OpenFoodFactsOptions = { country: "world" },
   ) {
-    this.baseUrl = `https://${options.country}.openfoodfacts.org`;
+    this.baseUrl = options.host
+      ? `https://${options.host}`
+      : `https://${options.country}.openfoodfacts.org`;
+
     this.fetch = fetch;
 
     this.rawv2 = createClient<pathsv2>({

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,9 +57,12 @@ export class OpenFoodFacts {
     fetch: typeof global.fetch,
     options: OpenFoodFactsOptions = { country: "world" },
   ) {
-    this.baseUrl = options.host
-      ? `https://${options.host}`
-      : `https://${options.country}.openfoodfacts.org`;
+    if (options.host && options.country) {
+      throw new Error("You must provide either `host` or `country`, not both.");
+    }
+
+    this.baseUrl =
+      options.host ?? `https://${options.country}.openfoodfacts.org`;
 
     this.fetch = fetch;
 


### PR DESCRIPTION
### What
- Adds support for a custom `host` in the `OpenFoodFacts` constructor
- Enables using the SDK with other Open*Facts domains (e.g. Beauty, Pet Food)
- Falls back to `country` if `host` is not provided (no breaking changes)

### Part of 
- #182 
