### PR TITLE
fix: Exporting Search APIs for consumption

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ export * from "./robotoff";
 export * from "./folksonomy";
 export * from "./prices";
 export * from "./nutripatrol";
+export * from "./search";
 
 export type OpenFoodFactsOptions = { country: string };
 


### PR DESCRIPTION
### What
While integrating search APIs in explorer project using nodejs SDK I faced this problem and so raising this PR.
Search APIs was not getting exposed from main.ts file in this project, because of which SDK consumers like explorer project can't use it. I am fixing this in this PR.

This change was missing from the search PR which got merged in nodejs project: #607 

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-explorer/issues/270
