### PR TITLE
fix: Fixed "body stream already read bug" in Folksonomy SDK

### DIFF
--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -34,7 +34,7 @@ export class Folksonomy {
     });
   }
 
-  private validateAuthToken(message?: string) {
+  private validateAuthToken(message?: string): void {
     if (!this.authToken) {
       throw new Error(
         message || "Auth token is required to perform this action",
@@ -49,17 +49,18 @@ export class Folksonomy {
    */
   async getKeys(): Promise<FolksonomyKey[]> {
     const res = await this.raw.GET("/keys");
-    return res.response.json();
+    return (res?.data ?? []) as FolksonomyKey[];
   }
 
   /**
    * Get the list of products that have a `key` or `key=value` if `value` is provided
    */
   async getProducts(key: string, value?: string): Promise<FolksonomyTag[]> {
+    const queryParams = value ? { k: key, v: value } : { k: key };
     const res = await this.raw.GET("/products", {
-      params: { query: { k: key, v: value } },
+      params: { query: queryParams },
     });
-    return res.response.json();
+    return (res?.data ?? []) as FolksonomyTag[];
   }
 
   async putTag(tag: FolksonomyTag): Promise<boolean> {
@@ -73,13 +74,14 @@ export class Folksonomy {
   /**
    * Get a list of existing tags for a product
    */
-  async getProduct(barcode: string) {
+  async getProduct(barcode: string): Promise<FolksonomyTag[]> {
     const res = await this.raw.GET("/product/{product}", {
       params: { path: { product: barcode } },
     });
 
-    return res;
+    return (res.data ?? []) as FolksonomyTag[];
   }
+
   /**
    * Update a product tag (or add it if it does not exist)
    *
@@ -107,7 +109,7 @@ export class Folksonomy {
    *
    * @returns if the tag was deleted
    */
-  async removeTag(tag: FolksonomyTag & { version: number }) {
+  async removeTag(tag: FolksonomyTag & { version: number }): Promise<boolean> {
     this.validateAuthToken();
 
     const res = await this.raw.DELETE("/product/{product}/{k}", {
@@ -117,7 +119,7 @@ export class Folksonomy {
       },
     });
 
-    return res;
+    return res.response.status === 200;
   }
 
   /**
@@ -156,11 +158,7 @@ export class Folksonomy {
       return { error: res.error };
     }
 
-    const token = (await res.response.json()) as {
-      access_token: string;
-      token_type: string;
-    };
-
-    return { token };
+    const data = res.data as { access_token: string; token_type: string };
+    return { token: data };
   }
 }


### PR DESCRIPTION
### What
I am working on task to remove direct server API calls in explorer project. While working on it, I came across couple of issues and bugs in Folksonomy nodejs SDK. In this PR, I am fixing these bugs. I have tested all the functions locally.

- Resolved bug https://github.com/openfoodfacts/openfoodfacts-nodejs/issues/618, which was causing the SDK to throw the exception "Failed to execute 'json' on 'Response': body stream already read." The issue stemmed from directly parsing the JSON response in multiple functions. Instead of this, `data` property of response should be used.

- Improved Type Definitions: Added and refined TypeScript return types for better type safety and clarity. Example: Explicitly defined return types for getProduct, removeTag, and validateAuthToken.

- I fixed the logic in getProducts. In this function, since `v` is an optional parameter, we should check beforehand whether v is null or not, and based on that we should define the query parameters.

### Fixes bug(s)
- https://github.com/openfoodfacts/openfoodfacts-nodejs/issues/618

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-explorer/issues/270
