### PR TITLE
feat: Added error handling for Folksonomy Write APIs

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -13,3 +13,14 @@ export type NutriPatrolError = {
     details?: any;
   };
 };
+
+// Common error object for unknown API errors
+export const UNKNOWN_API_ERROR: ApiError = {
+  detail: [
+    {
+      msg: "Unknown error occurred",
+      type: "error",
+      loc: [],
+    },
+  ],
+};

--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -67,7 +67,14 @@ export class Folksonomy {
 
     const res = await this.raw.PUT("/product", { body: tag });
 
-    return res.response.status === 200;
+    const isSuccess = res.response.status === 200;
+    if (!isSuccess) {
+      const error = res.error as ApiError;
+      if (error) {
+        throw new Error(`${JSON.stringify(error.detail)}`);
+      }
+    }
+    return isSuccess;
   }
 
   /**
@@ -99,7 +106,14 @@ export class Folksonomy {
       body: tag,
     });
 
-    return res.response.status === 200;
+    const isSuccess = res.response.status === 200;
+    if (!isSuccess) {
+      const error = res.error as ApiError;
+      if (error) {
+        throw new Error(`${JSON.stringify(error.detail)}`);
+      }
+    }
+    return isSuccess;
   }
 
   /**
@@ -117,7 +131,14 @@ export class Folksonomy {
       },
     });
 
-    return res;
+    const isSuccess = res.response.status === 200;
+    if (!isSuccess) {
+      const error = res.error as ApiError;
+      if (error) {
+        throw new Error(`${JSON.stringify(error.detail)}`);
+      }
+    }
+    return isSuccess;
   }
 
   /**

--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -2,7 +2,7 @@ import createClient from "openapi-fetch";
 
 import { paths, components } from "./schemas/folksonomy";
 import { formBody as formBodySerializer } from "./formbody";
-import { ApiError } from "./error";
+import { ApiError, UNKNOWN_API_ERROR } from "./error";
 import { DEFAULT_FOLKSONOMY_API_URL, USER_AGENT } from "./consts";
 
 export type FolksonomyTag = components["schemas"]["ProductTag"];
@@ -10,17 +10,6 @@ export type FolksonomyKey = {
   k: string;
   count: number;
   values: number;
-};
-
-// Common error object for unknown API errors
-const UNKNOWN_API_ERROR: ApiError = {
-  detail: [
-    {
-      msg: "Unknown error occurred",
-      type: "error",
-      loc: [],
-    },
-  ],
 };
 
 export class Folksonomy {

--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -78,16 +78,15 @@ export class Folksonomy {
    *
    * @returns if the tag was added or updated
    */
-  async putTag(tag: FolksonomyTag): Promise<[boolean, ApiError | null]> {
+  async putTag(tag: FolksonomyTag): Promise<ApiError | null> {
     this.validateAuthToken();
 
     const res = await this.raw.PUT("/product", { body: tag });
 
-    const isSuccess = res.response.status === 200;
-    if (!isSuccess) {
-      return [false, (res.error as ApiError) ?? null];
+    if (res.response.status !== 200) {
+      return (res.error as ApiError) ?? null;
     }
-    return [true, null];
+    return null;
   }
 
   /**
@@ -113,18 +112,17 @@ export class Folksonomy {
    *
    * @returns if the tag was added or updated
    */
-  async addTag(tag: FolksonomyTag): Promise<[boolean, ApiError | null]> {
+  async addTag(tag: FolksonomyTag): Promise<ApiError | null> {
     this.validateAuthToken();
 
     const res = await this.raw.POST("/product", {
       body: tag,
     });
 
-    const isSuccess = res.response.status === 200;
-    if (!isSuccess) {
-      return [false, (res.error as ApiError) ?? null];
+    if (res.response.status !== 200) {
+      return (res.error as ApiError) ?? null;
     }
-    return [true, null];
+    return null;
   }
 
   /**
@@ -141,7 +139,7 @@ export class Folksonomy {
    */
   async removeTag(
     tag: FolksonomyTag & { version: number },
-  ): Promise<[boolean, ApiError | null]> {
+  ): Promise<ApiError | null> {
     this.validateAuthToken();
 
     const res = await this.raw.DELETE("/product/{product}/{k}", {
@@ -151,11 +149,10 @@ export class Folksonomy {
       },
     });
 
-    const isSuccess = res.response.status === 200;
-    if (!isSuccess) {
-      return [false, (res.error as ApiError) ?? null];
+    if (res.response.status !== 200) {
+      return (res.error as ApiError) ?? null;
     }
-    return [true, null];
+    return null;
   }
 
   /**

--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -85,7 +85,7 @@ export class Folksonomy {
 
     const isSuccess = res.response.status === 200;
     if (!isSuccess) {
-      return [false, res.error as ApiError ?? null];
+      return [false, (res.error as ApiError) ?? null];
     }
     return [true, null];
   }
@@ -122,7 +122,7 @@ export class Folksonomy {
 
     const isSuccess = res.response.status === 200;
     if (!isSuccess) {
-      return [false, res.error as ApiError ?? null];
+      return [false, (res.error as ApiError) ?? null];
     }
     return [true, null];
   }
@@ -139,7 +139,9 @@ export class Folksonomy {
    *
    * @returns if the tag was deleted
    */
-  async removeTag(tag: FolksonomyTag & { version: number }): Promise<[boolean, ApiError | null]> {
+  async removeTag(
+    tag: FolksonomyTag & { version: number },
+  ): Promise<[boolean, ApiError | null]> {
     this.validateAuthToken();
 
     const res = await this.raw.DELETE("/product/{product}/{k}", {
@@ -151,7 +153,7 @@ export class Folksonomy {
 
     const isSuccess = res.response.status === 200;
     if (!isSuccess) {
-      return [false, res.error as ApiError ?? null];
+      return [false, (res.error as ApiError) ?? null];
     }
     return [true, null];
   }

--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -12,6 +12,17 @@ export type FolksonomyKey = {
   values: number;
 };
 
+// Common error object for unknown API errors
+const UNKNOWN_API_ERROR: ApiError = {
+  detail: [
+    {
+      msg: "Unknown error occurred",
+      type: "error",
+      loc: [],
+    },
+  ],
+};
+
 export class Folksonomy {
   private readonly fetch: typeof global.fetch;
   private readonly baseUrl: string;
@@ -84,7 +95,7 @@ export class Folksonomy {
     const res = await this.raw.PUT("/product", { body: tag });
 
     if (res.response.status !== 200) {
-      return (res.error as ApiError) ?? null;
+      return (res.error as ApiError) ?? UNKNOWN_API_ERROR;
     }
     return null;
   }
@@ -120,7 +131,7 @@ export class Folksonomy {
     });
 
     if (res.response.status !== 200) {
-      return (res.error as ApiError) ?? null;
+      return (res.error as ApiError) ?? UNKNOWN_API_ERROR;
     }
     return null;
   }
@@ -150,7 +161,7 @@ export class Folksonomy {
     });
 
     if (res.response.status !== 200) {
-      return (res.error as ApiError) ?? null;
+      return (res.error as ApiError) ?? UNKNOWN_API_ERROR;
     }
     return null;
   }

--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -78,19 +78,16 @@ export class Folksonomy {
    *
    * @returns if the tag was added or updated
    */
-  async putTag(tag: FolksonomyTag): Promise<boolean> {
+  async putTag(tag: FolksonomyTag): Promise<[boolean, ApiError | null]> {
     this.validateAuthToken();
 
     const res = await this.raw.PUT("/product", { body: tag });
 
     const isSuccess = res.response.status === 200;
     if (!isSuccess) {
-      const error = res.error as ApiError;
-      if (error) {
-        throw new Error(`${JSON.stringify(error.detail)}`);
-      }
+      return [false, res.error as ApiError ?? null];
     }
-    return isSuccess;
+    return [true, null];
   }
 
   /**
@@ -116,7 +113,7 @@ export class Folksonomy {
    *
    * @returns if the tag was added or updated
    */
-  async addTag(tag: FolksonomyTag): Promise<boolean> {
+  async addTag(tag: FolksonomyTag): Promise<[boolean, ApiError | null]> {
     this.validateAuthToken();
 
     const res = await this.raw.POST("/product", {
@@ -125,12 +122,9 @@ export class Folksonomy {
 
     const isSuccess = res.response.status === 200;
     if (!isSuccess) {
-      const error = res.error as ApiError;
-      if (error) {
-        throw new Error(`${JSON.stringify(error.detail)}`);
-      }
+      return [false, res.error as ApiError ?? null];
     }
-    return isSuccess;
+    return [true, null];
   }
 
   /**
@@ -145,7 +139,7 @@ export class Folksonomy {
    *
    * @returns if the tag was deleted
    */
-  async removeTag(tag: FolksonomyTag & { version: number }): Promise<boolean> {
+  async removeTag(tag: FolksonomyTag & { version: number }): Promise<[boolean, ApiError | null]> {
     this.validateAuthToken();
 
     const res = await this.raw.DELETE("/product/{product}/{k}", {
@@ -157,12 +151,9 @@ export class Folksonomy {
 
     const isSuccess = res.response.status === 200;
     if (!isSuccess) {
-      const error = res.error as ApiError;
-      if (error) {
-        throw new Error(`${JSON.stringify(error.detail)}`);
-      }
+      return [false, res.error as ApiError ?? null];
     }
-    return isSuccess;
+    return [true, null];
   }
 
   /**

--- a/tests/folksonomy.spec.ts
+++ b/tests/folksonomy.spec.ts
@@ -62,8 +62,9 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse("ok", true, 200));
 
-      const result = await client.putTag(tagData);
-      expect(result).toBe(true);
+      const [success, error] = await client.putTag(tagData);
+      expect(success).toBe(true);
+      expect(error).toBeNull();
     });
 
     it("should handle error when putting tag", async () => {
@@ -74,8 +75,9 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse(null, false, 500));
 
-      const result = await client.putTag(tagData);
-      expect(result).toBe(false);
+      const [success, error] = await client.putTag(tagData);
+      expect(success).toBe(false);
+      expect(error).toBeDefined();
     });
 
     it("should get product tags successfully", async () => {
@@ -100,8 +102,9 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse("ok", true, 200));
 
-      const result = await client.addTag(tagData);
-      expect(result).toBe(true);
+      const [success, error] = await client.addTag(tagData);
+      expect(success).toBe(true);
+      expect(error).toBeNull();
     });
 
     it("should handle error when adding tag", async () => {
@@ -112,8 +115,9 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse(null, false, 500));
 
-      const result = await client.addTag(tagData);
-      expect(result).toBe(false);
+      const [success, error] = await client.addTag(tagData);
+      expect(success).toBe(false);
+      expect(error).toBeDefined();
     });
 
     it("should remove tag successfully", async () => {
@@ -125,8 +129,9 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse("ok", true, 200));
 
-      const result = await client.removeTag(tagData);
-      expect(result).toBeDefined();
+      const [success, error] = await client.removeTag(tagData);
+      expect(success).toBe(true);
+      expect(error).toBeNull();
     });
 
     it("should handle error when removing tag", async () => {
@@ -138,8 +143,9 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse(null, false, 500));
 
-      const result = await client.removeTag(tagData);
-      expect(result).toBeDefined();
+      const [success, error] = await client.removeTag(tagData);
+      expect(success).toBe(false);
+      expect(error).toBeDefined();
     });
   });
 

--- a/tests/folksonomy.spec.ts
+++ b/tests/folksonomy.spec.ts
@@ -62,8 +62,7 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse("ok", true, 200));
 
-      const [success, error] = await client.putTag(tagData);
-      expect(success).toBe(true);
+      const error = await client.putTag(tagData);
       expect(error).toBeNull();
     });
 
@@ -75,8 +74,7 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse(null, false, 500));
 
-      const [success, error] = await client.putTag(tagData);
-      expect(success).toBe(false);
+      const error = await client.putTag(tagData);
       expect(error).toBeDefined();
     });
 
@@ -102,8 +100,7 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse("ok", true, 200));
 
-      const [success, error] = await client.addTag(tagData);
-      expect(success).toBe(true);
+      const error = await client.addTag(tagData);
       expect(error).toBeNull();
     });
 
@@ -115,8 +112,7 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse(null, false, 500));
 
-      const [success, error] = await client.addTag(tagData);
-      expect(success).toBe(false);
+      const error = await client.addTag(tagData);
       expect(error).toBeDefined();
     });
 
@@ -129,8 +125,7 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse("ok", true, 200));
 
-      const [success, error] = await client.removeTag(tagData);
-      expect(success).toBe(true);
+      const error = await client.removeTag(tagData);
       expect(error).toBeNull();
     });
 
@@ -143,8 +138,7 @@ describe("Folksonomy Wrapper", () => {
       };
       fetchMock.mockResolvedValue(mockResponse(null, false, 500));
 
-      const [success, error] = await client.removeTag(tagData);
-      expect(success).toBe(false);
+      const error = await client.removeTag(tagData);
       expect(error).toBeDefined();
     });
   });


### PR DESCRIPTION
### What
- Added error handling for write methods like putTag and removeTag. 
- Propagated the error message received from server. This is very helpful for nodejs SDK consumers and will help in debugging.
- We need to do JSON.stringify for error.detail because backend was sending different type of error responses like for some APIs, it is sending plain string, whereas for others it is sending nested JSON object.
- Tested all the changes locally.

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-explorer/issues/270
