### PR TITLE
fix: update /categories to /facets/categories in getTaxo

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -140,7 +140,7 @@ export class OpenFoodFacts {
     return this.getTaxo<Allergen>("allergens");
   }
   getCategories(): Promise<Taxonomy<Category>> {
-    return this.getTaxo<Category>("categories");
+    return this.getTaxo<Category>("facets/categories");
   }
   getCountries(): Promise<Taxonomy<Country>> {
     return this.getTaxo<Country>("countries");


### PR DESCRIPTION
### What
- Replaced the deprecated `/categories` endpoint with `/facets/categories` in `getTaxo` function inside `src/main.ts`.

### Screenshot
_Not applicable — no UI changes._

### Fixes bug(s)
- #617

### Part of 
- SDK update to match API structure (`facets/categories` endpoint update)
