### PR TITLE
chore: remove explorer specific methods, fix typings

### DIFF
--- a/src/off.ts
+++ b/src/off.ts
@@ -400,16 +400,19 @@ export class OpenFoodFacts {
    * ```
    * @returns A promise that resolves to a product object with the specified fields or undefined if not found
    */
-  async getProductV3<T extends Array<keyof ProductV3>>(
+  async getProductV3<T extends Array<keyof ProductV3 | "all">>(
     barcode: string,
     query?: Omit<
-      operationsv3["get-product-by-barcode"]["parameters"]["query"],
+      NonNullable<
+        operationsv3["get-product-by-barcode"]["parameters"]["query"]
+      >,
       "fields"
     > & {
       fields?: T;
     },
   ): Promise<
-    (ResponseStatusV3 & { product: Pick<ProductV3, T[number]> }) | undefined
+    // TODO: Remove once the OpenAPI spec is fixed to replace status_id with status
+    ProductState<Pick<ProductV3, Extract<T[number], keyof ProductV3>>>
   > {
     const res = await this.rawV3.GET("/api/v3/product/{barcode}", {
       params: {
@@ -417,6 +420,10 @@ export class OpenFoodFacts {
         query: { ...query, fields: query?.fields?.join(",") },
       },
     });
+
+    if ("error" in res) {
+      throw new Error(`${res.error}`);
+    }
 
     // @ts-expect-error - OpenAPI is wrong here!
     return res.data;
@@ -647,69 +654,6 @@ export class OpenFoodFacts {
   }
 
   /**
-   * Returns reduced product data suitable for displaying on cards
-   * @param barcode - The barcode of the product
-   * @param lang - Optional language code for localization
-   * @returns A promise that resolves to reduced product data
-   */
-  async getProductReducedForCard(
-    barcode: string,
-    lang?: string,
-  ): Promise<ProductState<ProductReduced>> {
-    const query: Record<string, string> = {
-      fields: REDUCED_FIELDS.join(","),
-    };
-
-    const selectedLang = lang || this.defaultOptions.lang;
-    if (selectedLang) {
-      query.lc = selectedLang;
-    }
-
-    const res = await this.rawV3.GET("/api/v3/product/{barcode}", {
-      params: {
-        path: { barcode },
-        query,
-      },
-    });
-
-    return res.data as ProductState<ProductReduced>;
-  }
-
-  /**
-   * Returns only the product name for a given barcode
-   * @param barcode - The barcode of the product
-   * @param lang - Optional language code for localization
-   * @returns A promise that resolves to the product name or null if not found
-   */
-  async getProductName(
-    barcode: string,
-    lang?: string,
-  ): Promise<Pick<ProductDataType, "product_name"> | null> {
-    const query: Record<string, string> = {
-      fields: "product_name",
-    };
-
-    const selectedLang = lang || this.defaultOptions.lang;
-    if (selectedLang) {
-      query.lc = selectedLang;
-    }
-
-    const res = await this.rawV3.GET("/api/v3/product/{barcode}", {
-      params: {
-        path: { barcode },
-        query,
-      },
-    });
-
-    const productState = res.data as ProductState<
-      Pick<ProductDataType, "product_name">
-    >;
-
-    if (productState?.status !== "success") return null;
-    return productState.product;
-  }
-
-  /**
    * Returns product data using the V2 API
    * @param barcode - The barcode of the product
    * @returns A promise that resolves to the product data or undefined if not found
@@ -839,9 +783,9 @@ export type ProductStateBase = {
 };
 
 export type ProductStateError = {
-  field: { id: string; value: string };
-  impact: { lc_name: string; name: string; id: string };
-  message: { lc_name: string; name: string; id: string };
+  field?: { id?: string; value?: string };
+  impact?: { lc_name?: string; name?: string; id?: string };
+  message?: { lc_name?: string; name?: string; id?: string };
 };
 
 export type ProductStateFailure = ProductStateBase & {
@@ -1027,23 +971,6 @@ export type ProductDataType = ProductDataSection & {
   };
   lang: string;
 };
-
-const REDUCED_FIELDS = [
-  "image_front_small_url",
-  "code",
-  "product_name",
-  "brands",
-  "quantity",
-  "nutriscore_grade",
-  "ecoscore_grade",
-  "nova_group",
-  "product_type",
-] as const;
-
-export type ProductReduced = Pick<
-  ProductDataType,
-  (typeof REDUCED_FIELDS)[number]
->;
 
 // By default, use v2
 export { ProductV2 as Product, SearchResultV2 as SearchResult };

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -160,6 +160,11 @@ describe("OpenFoodFacts", () => {
           },
         },
       );
+
+      expect(result.status).toBe("success");
+      if (result.status !== "success") return; // for type narrowing
+
+      expect(result.product).toEqual(productV3MockData.product);
     });
 
     it("should handle network errors when fetching product V3", async () => {
@@ -265,154 +270,6 @@ describe("OpenFoodFacts", () => {
       await expect(productsApi.getProductImages(testBarcode)).rejects.toThrow(
         "Network error",
       );
-    });
-  });
-
-  describe("getProductName", () => {
-    it("should fetch product name successfully", async () => {
-      const mockResponse = {
-        status: "success",
-        product: {
-          product_name: "Test Product",
-        },
-      };
-
-      mockV3Success(mockResponse);
-
-      const result = await productsApi.getProductName(testBarcode);
-
-      expect(result).toEqual({ product_name: "Test Product" });
-      expect(productsApi.rawV3.GET).toHaveBeenCalledWith(
-        "/api/v3/product/{barcode}",
-        {
-          params: {
-            path: { barcode: testBarcode },
-            query: { fields: "product_name" },
-          },
-        },
-      );
-    });
-
-    it("should fetch product name with language", async () => {
-      const mockResponse = {
-        status: "success",
-        product: {
-          product_name: "Produit Test",
-        },
-      };
-
-      mockV3Success(mockResponse);
-
-      const result = await productsApi.getProductName(testBarcode, "fr");
-
-      expect(result).toEqual({ product_name: "Produit Test" });
-      expect(productsApi.rawV3.GET).toHaveBeenCalledWith(
-        "/api/v3/product/{barcode}",
-        {
-          params: {
-            path: { barcode: testBarcode },
-            query: { fields: "product_name", lc: "fr" },
-          },
-        },
-      );
-    });
-
-    it("should return null when product not found", async () => {
-      const mockResponse = {
-        status: "failure",
-        errors: [],
-      };
-
-      mockV3Success(mockResponse);
-
-      const result = await productsApi.getProductName("invalid");
-
-      expect(result).toBeNull();
-    });
-
-    it("should handle network errors when fetching product name", async () => {
-      mockV3Error(networkError);
-
-      await expect(productsApi.getProductName(testBarcode)).rejects.toThrow(
-        "Network error",
-      );
-    });
-  });
-
-  describe("getProductReducedForCard", () => {
-    it("should fetch reduced product data successfully", async () => {
-      const mockResponse = {
-        status: "success",
-        product: {
-          code: testBarcode,
-          product_name: "Test Product",
-          brands: "Test Brand",
-          quantity: "100g",
-          nutriscore_grade: "c",
-          ecoscore_grade: "b",
-          nova_group: 3,
-          product_type: "food",
-          image_front_small_url: "https://example.com/image.jpg",
-        },
-      };
-
-      mockV3Success(mockResponse);
-
-      const result = await productsApi.getProductReducedForCard(testBarcode);
-
-      expect(result).toEqual(mockResponse);
-      expect(productsApi.rawV3.GET).toHaveBeenCalledWith(
-        "/api/v3/product/{barcode}",
-        {
-          params: {
-            path: { barcode: testBarcode },
-            query: {
-              fields:
-                "image_front_small_url,code,product_name,brands,quantity,nutriscore_grade,ecoscore_grade,nova_group,product_type",
-            },
-          },
-        },
-      );
-    });
-
-    it("should fetch reduced product data with language", async () => {
-      const mockResponse = {
-        status: "success",
-        product: {
-          code: testBarcode,
-          product_name: "Produit Test",
-        },
-      };
-
-      mockV3Success(mockResponse);
-
-      const result = await productsApi.getProductReducedForCard(
-        testBarcode,
-        "fr",
-      );
-
-      expect(result).toEqual(mockResponse);
-      expect(productsApi.rawV3.GET).toHaveBeenCalledWith(
-        "/api/v3/product/{barcode}",
-        {
-          params: {
-            path: { barcode: testBarcode },
-            query: {
-              fields:
-                "image_front_small_url,code,product_name,brands,quantity,nutriscore_grade,ecoscore_grade,nova_group,product_type",
-              lc: "fr",
-            },
-          },
-        },
-      );
-    });
-
-    it("should handle network errors when fetching reduced product data", async () => {
-      mockV3Error(networkError);
-
-      await expect(
-        productsApi.getProductReducedForCard(testBarcode),
-      ).rejects.toThrow("Network error");
     });
   });
 


### PR DESCRIPTION
### What
- Remove `getProductReducedForCard` and `ProductReduced` type. Can be achieved using `getProductV3`.
- Remove `getProductName`. Can be achieved using `getProductV3`.
