### PR TITLE
fix: send nested objects as json serialized in robotoff.annotate

### DIFF
--- a/src/formbody.ts
+++ b/src/formbody.ts
@@ -1,7 +1,37 @@
-export function formBody(params: Record<string, string>) {
+type FormBodyValue =
+  | string
+  | boolean
+  | number
+  | bigint
+  | symbol
+  | object
+  | undefined
+  | null;
+
+export function formBody(params: Record<string, FormBodyValue>) {
   const formBody = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
-    formBody.append(key, value);
+    if (value === null || value === undefined) {
+      // typeof null === object
+      // typeof undefined === undefined
+      continue;
+    }
+
+    switch (typeof value) {
+      case "string":
+        formBody.append(key, value);
+        break;
+      case "boolean":
+      case "number":
+      case "bigint":
+        formBody.append(key, String(value));
+        break;
+      case "object":
+        formBody.append(key, JSON.stringify(value));
+        break;
+      default:
+        throw new Error(`Cannot formBody-fy a ${typeof value}!`);
+    }
   }
-  return formBody;
+  return formBody.toString();
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -45,15 +45,10 @@ export class Robotoff {
   }
 
   async annotate(body: RobotoffAnnotateBody) {
-    const stringifyValues = (body: RobotoffAnnotateBody) => {
-      return Object.fromEntries(
-        Object.entries(body).map(([key, value]) => [key, String(value)]),
-      );
-    };
     return this.raw.POST("/insights/annotate", {
       body: body,
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      bodySerializer: (body) => formBody(stringifyValues(body)),
+      bodySerializer: formBody,
     });
   }
 

--- a/tests/formbody.spec.ts
+++ b/tests/formbody.spec.ts
@@ -1,0 +1,60 @@
+import { formBody } from "../src/formbody";
+
+describe(formBody, () => {
+  it("should correctly handle strings", () => {
+    const obj1 = { param1: "value1" };
+    expect(decodeURIComponent(formBody(obj1))).toBe("param1=value1");
+    const obj2 = { param1: "value1", param2: "value2" };
+    expect(decodeURIComponent(formBody(obj2))).toBe(
+      "param1=value1&param2=value2",
+    );
+  });
+
+  it("should correctly handle numbers", () => {
+    const obj1 = { param1: 1 };
+    expect(decodeURIComponent(formBody(obj1))).toBe("param1=1");
+    const obj2 = { param1: "value1", param2: 2 };
+    expect(decodeURIComponent(formBody(obj2))).toBe("param1=value1&param2=2");
+  });
+
+  it("should correctly handle booleans", () => {
+    const obj1 = { param1: true };
+    expect(decodeURIComponent(formBody(obj1))).toBe("param1=true");
+  });
+
+  it("should correctly handle objects", () => {
+    const obj1 = { param1: { nestedParam1: "nestedvalue1" } };
+    expect(decodeURIComponent(formBody(obj1))).toBe(
+      `param1={"nestedParam1":"nestedvalue1"}`,
+    );
+    const obj2 = { param1: { nestedParam1: "nestedvalue1" }, param2: 2 };
+    expect(decodeURIComponent(formBody(obj2))).toBe(
+      `param1={"nestedParam1":"nestedvalue1"}&param2=2`,
+    );
+  });
+
+  it("should correctly handle bigints", () => {
+    const obj = { param1: BigInt(1) };
+    expect(decodeURIComponent(formBody(obj))).toBe(`param1=1`);
+  });
+
+  it("should error on functions", () => {
+    const obj = { param1: () => "param1" };
+    expect(() => formBody(obj)).toThrow("Cannot formBody-fy a function");
+  });
+
+  it("should error on symbols", () => {
+    const obj = { param1: Symbol("value") };
+    expect(() => formBody(obj)).toThrow("Cannot formBody-fy a symbol");
+  });
+
+  it("should ignore null", () => {
+    const obj = { param1: "value1", param2: null };
+    expect(decodeURIComponent(formBody(obj))).toBe("param1=value1");
+  });
+
+  it("should ignore undefined", () => {
+    const obj = { param1: "value1", param2: undefined };
+    expect(decodeURIComponent(formBody(obj))).toBe("param1=value1");
+  });
+});


### PR DESCRIPTION
### What
- Previously, if an endpoint requested application/x-www-form-urlencoded MIME type, we would send nested JSON objects as [object Object]. We should now handle that case by serializing it to JSON.

Fixes https://github.com/openfoodfacts/openfoodfacts-webcomponents/issues/284

