### PR TITLE
chore: transpile down to ES2017

### DIFF
--- a/src/facets-kp.ts
+++ b/src/facets-kp.ts
@@ -13,11 +13,14 @@ export type FacetKnowledgePanelResponse = {
  * @param baseUrl - The base URL for the API. If not provided, it defaults to "https://facets-kp.openfoodfacts.org".
  */
 export class FacetsKp {
-  readonly fetch: typeof window.fetch;
+  readonly fetch: typeof globalThis.fetch;
   readonly baseUrl: string;
   readonly client: ReturnType<typeof createClient<paths>>;
 
-  constructor(fetch: typeof window.fetch, { baseUrl }: { baseUrl?: string }) {
+  constructor(
+    fetch: typeof globalThis.fetch,
+    { baseUrl }: { baseUrl?: string },
+  ) {
     this.fetch = fetch;
     this.baseUrl = baseUrl || "https://facets-kp.openfoodfacts.org";
     this.client = createClient<paths>({

--- a/src/off.ts
+++ b/src/off.ts
@@ -229,9 +229,12 @@ export class OpenFoodFacts {
    * Creates a fetch wrapper that adds User-Agent header
    */
   private createUserAgentFetch(
-    fetch: typeof global.fetch,
-  ): typeof global.fetch {
-    return (url: RequestInfo | URL, init?: RequestInit) => {
+    fetch: typeof globalThis.fetch,
+  ): typeof globalThis.fetch {
+    return (
+      url: string | URL | globalThis.Request,
+      init?: globalThis.RequestInit,
+    ) => {
       const headers = new Headers(init?.headers);
       headers.set("User-Agent", this.customUserAgent);
       return fetch(url, { ...init, headers });
@@ -245,7 +248,10 @@ export class OpenFoodFacts {
     fetch: typeof global.fetch,
     options: OpenFoodFactsOptions,
   ): typeof global.fetch {
-    return async (url: RequestInfo | URL, init?: RequestInit) => {
+    return async (
+      url: string | URL | globalThis.Request | URL,
+      init?: globalThis.RequestInit,
+    ) => {
       const headers = new Headers(init?.headers);
 
       if (this.accessToken == null) {
@@ -526,7 +532,7 @@ export class OpenFoodFacts {
     const res = await this.fetch(
       `${this.baseUrl}/facets/${facet}.json?${params}`,
     );
-    return await res.json();
+    return (await res.json()) as FacetResponse;
   }
 
   async getFacetValue(
@@ -542,7 +548,7 @@ export class OpenFoodFacts {
     const res = await this.fetch(
       `${this.baseUrl}/facets/${facet}/${value}.json?${params}`,
     );
-    return await res.json();
+    return (await res.json()) as FacetValueResponse;
   }
 }
 

--- a/src/prices.ts
+++ b/src/prices.ts
@@ -13,7 +13,7 @@ export class PricesApi {
   private readonly client: ReturnType<typeof createClient<paths>>;
 
   constructor(
-    fetch: typeof window.fetch,
+    fetch: typeof globalThis.fetch,
     options: { baseUrl: string; authToken?: string } = { baseUrl: BASE_URL },
   ) {
     this.client = createClient({

--- a/src/search.ts
+++ b/src/search.ts
@@ -20,7 +20,7 @@ export class SearchApi {
   private readonly client: ReturnType<typeof createClient<paths>>;
 
   constructor(
-    fetch: typeof window.fetch,
+    fetch: typeof globalThis.fetch,
     options: { baseUrl: string } = { baseUrl: SEARCH_BASE_URL },
   ) {
     this.client = createClient<paths>({

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,13 @@
 {
   "compilerOptions": {
-    "forceConsistentCasingInFileNames": true,
     "rootDir": "./src",
     "strict": true,
 
+    "lib": ["ES2017"],
+    "target": "ES2017",
+
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true
   },

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
     "moduleResolution": "node",
 
     "outDir": "./dist/cjs",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "nodenext",
-    "target": "ES2020",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
 
     "outDir": "dist/esm",


### PR DESCRIPTION
### What
- Unify CJS and ESM target as ES2017
- Should be supported by virtually anything useful, like the majority of browsers and any supported NodeJS version