### PR TITLE
fix: Include credentials in all Robotoff API requests

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -41,6 +41,7 @@ export class Robotoff {
       headers: {
         "User-Agent": USER_AGENT,
       },
+      credentials: "include",
     });
   }
 


### PR DESCRIPTION
This is an alternative to the same change in openfoodfacts/openfoodfacts-webcomponents#306 - that one has one step less to test and deploy, but this one would potentially benefit also other users of the SDK.