### PR TITLE
fix: Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -1,4 +1,8 @@
 name: Add bugs to the relevant GitHub Projects
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/9](https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/9)

To address the identified problem, we should add an explicit `permissions` block to either the root of the workflow or to the involved jobs. Since both jobs in this workflow only require interacting with GitHub Projects (using custom tokens) and possibly issues and pull requests, these jobs do not need broad write permissions. Therefore, set the global workflow-level `permissions` to a minimal set: for project or issue management, this is typically `contents: read`, `issues: write`, and `pull-requests: write`. This should be done by inserting a `permissions` section near the top of the file, just after (or before) the `on:` workflow triggers.

**How to make the change in detail:**  
Edit `.github/workflows/github-projects.yml`.  
Insert the following lines (with proper YAML indentation) after the `name:` or before the `on:` section (the order is valid in both cases, but conventionally, it's placed right after `name:`):

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

This will ensure the GITHUB_TOKEN used in the jobs is minimized to only what's needed, not inadvertently granting excess privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
