### PR TITLE
fix: Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -11,6 +11,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/20](https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/20)

To resolve this problem, add a `permissions` block to the job (or workflow root). The permissions should be limited to the least needed for the action. For the `amannn/action-semantic-pull-request` action, typically only reading PR content/titles is needed. However, if you want to enable the action to comment or update the PR (e.g., to add a status or label), you may want to grant `pull-requests: write`. We recommend starting with:
```yaml
      permissions:
        contents: read
        pull-requests: write
```
at the job level (under `main:` at line 11). If later you confirm only read is needed, restrict further. No other regions or imports are needed for YAML workflows.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
