### PR TITLE
fix: add permissions to codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
fix: add permissions to codeql-analysis.yml- #727

 For CodeQL analysis jobs, the absolute minimum is usually `contents: read`, but if additional permissions are required (e.g., uploading SARIF results, creating issues, etc.), those can be added as needed. To ensure least privilege, add the following to the relevant scope in `.github/workflows/codeql-analysis.yml`:

- Add the following under the job definition (`CodeQL-Build:`), indented properly:
  ```yaml
  permissions:
    contents: read
  ```
