### PR TITLE
fix: Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -1,4 +1,8 @@
 name: Add bugs to the relevant GitHub Projects
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/11](https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/11)

To correct this issue, you should explicitly set the `permissions` key in the workflow, either at the root (to apply to all jobs) or at the individual job level (to precisely scope each job’s needs). The jobs in this workflow only need minimal permissions—typically just the ability to write to issues, as they interact with GitHub Projects using the provided token. The best fix is to add the `permissions` block at the root of the workflow, immediately below the workflow `name`, limiting `contents` to `read` and `issues` to `write` (or, if the workflow also manages PRs, `pull-requests: write` as well). No other modifications are needed, and no imports or extra methods are necessary.

Edit `.github/workflows/github-projects.yml`, inserting the following lines immediately after the `name:` declaration and before the `on:` block at the top:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

If you prefer job-level permissions, you could insert the equivalent block under each job, but workflow-level is more concise and covers all jobs by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
