### PR TITLE
fix: Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -11,6 +11,9 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: mschilde/auto-label-merge-conflicts@5981f8933e92b78098af86b9e33fe0871cc7a3be # v2.0 (2020-01-27)
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/10](https://github.com/openfoodfacts/openfoodfacts-js/security/code-scanning/10)

To remediate the problem, explicitly set the `permissions` block within the workflow. Since the action only needs to label pull requests (i.e., needs to write to pull requests), and may need to read repository contents (though this is usually not necessary for labeling), we should assign `contents: read` and `pull-requests: write`. This should be set at the job level under `triage` (lines 12-13), so that only that job receives these permissions. No other jobs exist in this workflow. The change involves inserting a `permissions:` block directly under the `runs-on` key and before `steps:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
