### PR TITLE
feat: Implement logos & labels crops fetch and annotate routes #528

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -99,37 +99,33 @@ export class Robotoff {
     });
   }
 
-  annotateLogos(
-    annotations: LogoAnnotation[]
-) {
-  return this.raw.POST("/images/logos/annotate", {
-    body: { annotations },
-  });
-}
-
-
- resetLogo(logoId: number) {
-  return this.raw.POST("/images/logos/{logo_id}/reset", {
-    params: { path: { logo_id: logoId } },
-  });
-}
-getLogoAnnotations(logoId?: number, index = 0, count = 25) {
-  const paginationParams = {
-    params: {
-      query: { index, count },
-    },
-  };
-  if (logoId != null) {
-    return this.raw.GET("/ann/search/{logo_id}", {
-      ...paginationParams,
-      params: {
-        ...paginationParams.params,
-        path: { logo_id: logoId },
-      }, 
-    }); 
+  annotateLogos(annotations: LogoAnnotation[]) {
+    return this.raw.POST("/images/logos/annotate", {
+      body: { annotations },
+    });
   }
 
-  return this.raw.GET("/ann/search", paginationParams);
-}
-  
+  resetLogo(logoId: number) {
+    return this.raw.POST("/images/logos/{logo_id}/reset", {
+      params: { path: { logo_id: logoId } },
+    });
+  }
+  getLogoAnnotations(logoId?: number, index = 0, count = 25) {
+    const paginationParams = {
+      params: {
+        query: { index, count },
+      },
+    };
+    if (logoId != null) {
+      return this.raw.GET("/ann/search/{logo_id}", {
+        ...paginationParams,
+        params: {
+          ...paginationParams.params,
+          path: { logo_id: logoId },
+        },
+      });
+    }
+
+    return this.raw.GET("/ann/search", paginationParams);
+  }
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -22,6 +22,25 @@ export type QuestionsResponse = {
   status?: "found" | "no_questions";
   questions?: Question[];
 };
+export type LogoSearchParams = {
+  server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
+  barcode?: string;
+  count?: number;
+  type?: string;
+  value?: string;
+  taxonomy_value?: string;
+  min_confidence?: number;
+  random?: boolean;
+  annotated?: boolean | null;
+};
+export type LogoAnnotation = {
+  logo_id: number;
+  type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
+  value: string | null;
+  server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
+};
+
+
 
 export class Robotoff {
   /** The fetch function used for every request */
@@ -87,29 +106,14 @@ export class Robotoff {
     });
     return result.data;
   }
-  searchLogos(params: {
-  server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
-  barcode?: string;
-  count?: number;
-  type?: string;
-  value?: string;
-  taxonomy_value?: string;
-  min_confidence?: number;
-  random?: boolean;
-  annotated?: boolean | null;
-  }) {
+  searchLogos(params: LogoSearchParams) {
     return this.raw.GET("/images/logos/search", {
       params: { query: params },
     });
   }
 
  annotateLogos(
-  annotations: Array<{
-    logo_id: number;
-    type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
-    value: string | null;
-    server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
-  }>
+  annotations: LogoAnnotation[]
 ) {
   return this.raw.POST("/images/logos/annotate", {
     body: { annotations },
@@ -124,15 +128,26 @@ export class Robotoff {
 }
 
 getLogoAnnotations(logoId?: number, index = 0, count = 25) {
-  const path = logoId
-    ? "/ann/search/{logo_id}"
-    : "/ann/search";
-  return this.raw.GET(path as any, {
+  const common = {
     params: {
-      path: logoId ? { logo_id: logoId } : undefined,
       query: { index, count },
     },
-  });
+  };
+  if (logoId != null) {
+    interface AnnSearchByIdParams {
+      path: { logo_id: number };
+      query: { index: number; count: number };
+    }
+    return this.raw.GET("/ann/search/{logo_id:int}", {
+      ...common,
+      params: {
+        ...common.params,
+        path: { logo_id: logoId },
+      } as AnnSearchByIdParams, 
+    } as any); 
+  }
+
+  return this.raw.GET("/ann/search", common);
 }
   
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -35,12 +35,19 @@ export type LogoSearchParams = {
 };
 export type LogoAnnotation = {
   logo_id: number;
-  type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
+  type:
+    | "brand"
+    | "category"
+    | "label"
+    | "no_logo"
+    | "nutritional_label"
+    | "packager_code"
+    | "packaging"
+    | "qr_code"
+    | "store";
   value: string | null;
   server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
 };
-
-
 
 export class Robotoff {
   /** The fetch function used for every request */
@@ -112,42 +119,38 @@ export class Robotoff {
     });
   }
 
- annotateLogos(
-  annotations: LogoAnnotation[]
-) {
-  return this.raw.POST("/images/logos/annotate", {
-    body: { annotations },
-  });
-}
-
-
- resetLogo(logoId: number) {
-  return this.raw.POST("/images/logos/{logo_id}/reset", {
-    params: { path: { logo_id: logoId } },
-  });
-}
-
-getLogoAnnotations(logoId?: number, index = 0, count = 25) {
-  const common = {
-    params: {
-      query: { index, count },
-    },
-  };
-  if (logoId != null) {
-    interface AnnSearchByIdParams {
-      path: { logo_id: number };
-      query: { index: number; count: number };
-    }
-    return this.raw.GET("/ann/search/{logo_id:int}", {
-      ...common,
-      params: {
-        ...common.params,
-        path: { logo_id: logoId },
-      } as AnnSearchByIdParams, 
-    } as any); 
+  annotateLogos(annotations: LogoAnnotation[]) {
+    return this.raw.POST("/images/logos/annotate", {
+      body: { annotations },
+    });
   }
 
-  return this.raw.GET("/ann/search", common);
-}
-  
+  resetLogo(logoId: number) {
+    return this.raw.POST("/images/logos/{logo_id}/reset", {
+      params: { path: { logo_id: logoId } },
+    });
+  }
+
+  getLogoAnnotations(logoId?: number, index = 0, count = 25) {
+    const common = {
+      params: {
+        query: { index, count },
+      },
+    };
+    if (logoId != null) {
+      interface AnnSearchByIdParams {
+        path: { logo_id: number };
+        query: { index: number; count: number };
+      }
+      return this.raw.GET("/ann/search/{logo_id:int}", {
+        ...common,
+        params: {
+          ...common.params,
+          path: { logo_id: logoId },
+        } as AnnSearchByIdParams,
+      } as any);
+    }
+
+    return this.raw.GET("/ann/search", common);
+  }
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -113,7 +113,6 @@ export class Robotoff {
     params: { path: { logo_id: logoId } },
   });
 }
-
 getLogoAnnotations(logoId?: number, index = 0, count = 25) {
   const paginationParams = {
     params: {

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -117,7 +117,7 @@ export class Robotoff {
 // It defines /ann/search/{logo_id:int} but does not declare logo_id in parameters.path.
 // Once schema is fixed, cast can be removed.
 getLogoAnnotations(logoId?: number, index = 0, count = 25) {
-  const common = {
+  const paginationParams = {
     params: {
       query: { index, count },
     },
@@ -128,15 +128,15 @@ getLogoAnnotations(logoId?: number, index = 0, count = 25) {
       query: { index: number; count: number };
     }
     return this.raw.GET("/ann/search/{logo_id:int}", {
-      ...common,
+      ...paginationParams,
       params: {
-        ...common.params,
+        ...paginationParams.params,
         path: { logo_id: logoId },
       } as AnnSearchByIdParams, 
     } as any); 
   }
 
-  return this.raw.GET("/ann/search", common);
+  return this.raw.GET("/ann/search", paginationParams);
 }
   
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -22,6 +22,12 @@ export type QuestionsResponse = {
   status?: "found" | "no_questions";
   questions?: Question[];
 };
+// export type LogoSearchParams =
+  // paths["/images/logos/search"]["get"]["parameters"]["query"];
+
+// export type LogoAnnotation =
+  // paths["/images/logos/annotate"]["post"]["requestBody"]["content"]["application/json"]["annotations"][number];
+
 export type LogoSearchParams = {
   server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
   barcode?: string;
@@ -106,6 +112,7 @@ export class Robotoff {
     });
     return result.data;
   }
+
   searchLogos(params: LogoSearchParams) {
     return this.raw.GET("/images/logos/search", {
       params: { query: params },
@@ -126,7 +133,9 @@ export class Robotoff {
     params: { path: { logo_id: logoId } },
   });
 }
-
+// TODO: Fix OpenAPI schema.
+// It defines /ann/search/{logo_id:int} but does not declare logo_id in parameters.path.
+// Once schema is fixed, cast can be removed.
 getLogoAnnotations(logoId?: number, index = 0, count = 25) {
   const common = {
     params: {

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -110,22 +110,19 @@ export class Robotoff {
       params: { path: { logo_id: logoId } },
     });
   }
+
   getLogoAnnotations(logoId?: number, index = 0, count = 25) {
-    const paginationParams = {
-      params: {
-        query: { index, count },
-      },
-    };
-    if (logoId != null) {
-      return this.raw.GET("/ann/search/{logo_id}", {
-        ...paginationParams,
-        params: {
-          ...paginationParams.params,
-          path: { logo_id: logoId },
-        },
-      });
+    const paginationParams = { query: { index, count } };
+
+    if (logoId == null) {
+      return this.raw.GET("/ann/search", { params: paginationParams });
     }
 
-    return this.raw.GET("/ann/search", paginationParams);
+    return this.raw.GET("/ann/search/{logo_id}", {
+      params: {
+        ...paginationParams,
+        path: { logo_id: logoId },
+      },
+    });
   }
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -35,19 +35,12 @@ export type LogoSearchParams = {
 };
 export type LogoAnnotation = {
   logo_id: number;
-  type:
-    | "brand"
-    | "category"
-    | "label"
-    | "no_logo"
-    | "nutritional_label"
-    | "packager_code"
-    | "packaging"
-    | "qr_code"
-    | "store";
+  type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
   value: string | null;
   server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
 };
+
+
 
 export class Robotoff {
   /** The fetch function used for every request */
@@ -119,38 +112,42 @@ export class Robotoff {
     });
   }
 
-  annotateLogos(annotations: LogoAnnotation[]) {
-    return this.raw.POST("/images/logos/annotate", {
-      body: { annotations },
-    });
-  }
+  annotateLogos(
+    annotations: LogoAnnotation[]
+) {
+  return this.raw.POST("/images/logos/annotate", {
+    body: { annotations },
+  });
+}
 
-  resetLogo(logoId: number) {
-    return this.raw.POST("/images/logos/{logo_id}/reset", {
-      params: { path: { logo_id: logoId } },
-    });
-  }
 
-  getLogoAnnotations(logoId?: number, index = 0, count = 25) {
-    const common = {
-      params: {
-        query: { index, count },
-      },
-    };
-    if (logoId != null) {
-      interface AnnSearchByIdParams {
-        path: { logo_id: number };
-        query: { index: number; count: number };
-      }
-      return this.raw.GET("/ann/search/{logo_id:int}", {
-        ...common,
-        params: {
-          ...common.params,
-          path: { logo_id: logoId },
-        } as AnnSearchByIdParams,
-      } as any);
+ resetLogo(logoId: number) {
+  return this.raw.POST("/images/logos/{logo_id}/reset", {
+    params: { path: { logo_id: logoId } },
+  });
+}
+
+getLogoAnnotations(logoId?: number, index = 0, count = 25) {
+  const common = {
+    params: {
+      query: { index, count },
+    },
+  };
+  if (logoId != null) {
+    interface AnnSearchByIdParams {
+      path: { logo_id: number };
+      query: { index: number; count: number };
     }
-
-    return this.raw.GET("/ann/search", common);
+    return this.raw.GET("/ann/search/{logo_id:int}", {
+      ...common,
+      params: {
+        ...common.params,
+        path: { logo_id: logoId },
+      } as AnnSearchByIdParams, 
+    } as any); 
   }
+
+  return this.raw.GET("/ann/search", common);
+}
+  
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -22,31 +22,11 @@ export type QuestionsResponse = {
   status?: "found" | "no_questions";
   questions?: Question[];
 };
-// export type LogoSearchParams =
-  // paths["/images/logos/search"]["get"]["parameters"]["query"];
+export type LogoSearchParams =
+  paths["/images/logos/search"]["get"]["parameters"]["query"];
 
-// export type LogoAnnotation =
-  // paths["/images/logos/annotate"]["post"]["requestBody"]["content"]["application/json"]["annotations"][number];
-
-export type LogoSearchParams = {
-  server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
-  barcode?: string;
-  count?: number;
-  type?: string;
-  value?: string;
-  taxonomy_value?: string;
-  min_confidence?: number;
-  random?: boolean;
-  annotated?: boolean | null;
-};
-export type LogoAnnotation = {
-  logo_id: number;
-  type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
-  value: string | null;
-  server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
-};
-
-
+export type LogoAnnotation =
+  paths["/images/logos/annotate"]["post"]["requestBody"]["content"]["application/json"]["annotations"][number];
 
 export class Robotoff {
   /** The fetch function used for every request */

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -113,9 +113,7 @@ export class Robotoff {
     params: { path: { logo_id: logoId } },
   });
 }
-// TODO: Fix OpenAPI schema.
-// It defines /ann/search/{logo_id:int} but does not declare logo_id in parameters.path.
-// Once schema is fixed, cast can be removed.
+
 getLogoAnnotations(logoId?: number, index = 0, count = 25) {
   const paginationParams = {
     params: {
@@ -123,17 +121,13 @@ getLogoAnnotations(logoId?: number, index = 0, count = 25) {
     },
   };
   if (logoId != null) {
-    interface AnnSearchByIdParams {
-      path: { logo_id: number };
-      query: { index: number; count: number };
-    }
-    return this.raw.GET("/ann/search/{logo_id:int}", {
+    return this.raw.GET("/ann/search/{logo_id}", {
       ...paginationParams,
       params: {
         ...paginationParams.params,
         path: { logo_id: logoId },
-      } as AnnSearchByIdParams, 
-    } as any); 
+      }, 
+    }); 
   }
 
   return this.raw.GET("/ann/search", paginationParams);

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -87,4 +87,52 @@ export class Robotoff {
     });
     return result.data;
   }
+  searchLogos(params: {
+  server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
+  barcode?: string;
+  count?: number;
+  type?: string;
+  value?: string;
+  taxonomy_value?: string;
+  min_confidence?: number;
+  random?: boolean;
+  annotated?: boolean | null;
+  }) {
+    return this.raw.GET("/images/logos/search", {
+      params: { query: params },
+    });
+  }
+
+ annotateLogos(
+  annotations: Array<{
+    logo_id: number;
+    type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
+    value: string | null;
+    server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
+  }>
+) {
+  return this.raw.POST("/images/logos/annotate", {
+    body: { annotations },
+  });
+}
+
+
+ resetLogo(logoId: number) {
+  return this.raw.POST("/images/logos/{logo_id}/reset", {
+    params: { path: { logo_id: logoId } },
+  });
+}
+
+getLogoAnnotations(logoId?: number, index = 0, count = 25) {
+  const path = logoId
+    ? "/ann/search/{logo_id}"
+    : "/ann/search";
+  return this.raw.GET(path as any, {
+    params: {
+      path: logoId ? { logo_id: logoId } : undefined,
+      query: { index, count },
+    },
+  });
+}
+  
 }

--- a/tests/robotoff.spec.ts
+++ b/tests/robotoff.spec.ts
@@ -1,53 +1,72 @@
-import { Robotoff } from "../src";
-
+import { LogoAnnotation, Robotoff } from "../src";
+import { TestUtils } from "./utils/test-utils";
 describe("Robotoff", () => {
+  let fetchMock: jest.Mock;
+  let robotoff: Robotoff;
+  let testLogoId = 12345;
+  const mockResponse = TestUtils.mockResponse;
 
-    const robotoff = new Robotoff(fetch as any);
-    let testLogoId: number;
-    it("searches logo crops", async () => {
- 
-        const res = await robotoff.searchLogos({
-          barcode: "5410041040807",
-          count: 2,
-        });
- 
-        expect(res.data).toBeDefined();
-        expect(res.data?.logos).toBeDefined();
-        expect(res.data!.logos.length).toBeGreaterThan(0);
-        testLogoId = res.data!.logos[0].id as number;
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as any;
+    robotoff = new Robotoff(fetchMock);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("searches logo crops", async () => {
+    const mockData = { logos: [{ id: testLogoId }], count: 1 };
+    fetchMock.mockResolvedValue(mockResponse(mockData));
+
+    const res = await robotoff.searchLogos({
+      barcode: "5410041040807",
+      count: 2,
     });
-    it("annotates a logo", async () => {
-        const annotations: {
-            logo_id: number;
-            type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
-            value: string | null;
-            server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
-          }[] = [
-            {
-              logo_id: testLogoId,
-              type: "brand",
-              value: "test-brand",
-              server_type: "off",
-            },
-        ];
+    expect(res.data).toBeDefined();
+    expect(res.data?.logos).toBeDefined();
+    expect(res.data!.logos.length).toBeGreaterThan(0);
+    testLogoId = res.data!.logos[0].id as number;
+  });
+  it("annotates a logo", async () => {
+    const annotations: LogoAnnotation[] = [
+      {
+        logo_id: testLogoId,
+        type: "brand",
+        value: "test-brand",
+        server_type: "off",
+      },
+    ];
 
-        const res = await robotoff.annotateLogos(annotations);
-        expect(res).toBeDefined();
-    });
+    const mockData = { annotated: 1 };
+    fetchMock.mockResolvedValue(mockResponse(mockData));
 
+    const res = await robotoff.annotateLogos(annotations);
 
-    it("gets logo annotations", async () => {
-        const res = await robotoff.getLogoAnnotations(testLogoId);
+    expect(res.data).toBeDefined();
+    expect(res.data?.annotated).toBeGreaterThan(0);
+  });
 
-        expect(res.data).toBeDefined();
-        expect(Array.isArray(res.data?.annotations || [])).toBe(true);
-    
-    }, 15000);
+  it("gets logo annotations", async () => {
+    const mockData = {
+      annotations: [
+        { logo_id: testLogoId, type: "brand", value: "test-brand" },
+      ],
+    };
+    fetchMock.mockResolvedValue(mockResponse(mockData));
 
-    it("resets a logo", async () => {
-        const res = await robotoff.resetLogo(testLogoId);
-    
-        expect(res).toBeDefined();
-    });
+    const res = await robotoff.getLogoAnnotations(testLogoId);
 
+    expect(res.data).toBeDefined();
+    expect(Array.isArray(res.data?.annotations)).toBe(true);
+    expect(res.data?.annotations.length).toBeGreaterThan(0);
+  }, 15000);
+
+  it("resets a logo", async () => {
+    fetchMock.mockResolvedValue(mockResponse(null, true, 204));
+
+    const res = await robotoff.resetLogo(testLogoId);
+
+    expect(res.response.status).toBe(204);
+  });
 });

--- a/tests/robotoff.spec.ts
+++ b/tests/robotoff.spec.ts
@@ -34,7 +34,6 @@ describe("Robotoff", () => {
         logo_id: testLogoId,
         type: "brand",
         value: "test-brand",
-        server_type: "off",
       },
     ];
 

--- a/tests/robotoff.spec.ts
+++ b/tests/robotoff.spec.ts
@@ -26,7 +26,7 @@ describe("Robotoff", () => {
     expect(res.data).toBeDefined();
     expect(res.data?.logos).toBeDefined();
     expect(res.data!.logos.length).toBeGreaterThan(0);
-    testLogoId = res.data!.logos[0].id as number;
+    expect(res.data!.logos[0].id).toBe(testLogoId);
   });
   it("annotates a logo", async () => {
     const annotations: LogoAnnotation[] = [
@@ -59,7 +59,14 @@ describe("Robotoff", () => {
 
     expect(res.data).toBeDefined();
     expect(Array.isArray(res.data?.annotations)).toBe(true);
-    expect(res.data?.annotations.length).toBeGreaterThan(0);
+    expect(res.data!.annotations.length).toBe(1);
+
+    expect(res.data!.annotations[0]).toEqual({
+      logo_id: testLogoId,
+      type: "brand",
+      value: "test-brand",
+    });
+
   }, 15000);
 
   it("resets a logo", async () => {
@@ -67,6 +74,8 @@ describe("Robotoff", () => {
 
     const res = await robotoff.resetLogo(testLogoId);
 
-    expect(res.response.status).toBe(204);
+    expect(res.error).toBeUndefined();
+    expect(res.data).toBeUndefined();
+  
   });
 });

--- a/tests/robotoff.spec.ts
+++ b/tests/robotoff.spec.ts
@@ -48,9 +48,7 @@ describe("Robotoff", () => {
 
   it("gets logo annotations", async () => {
     const mockData = {
-      results: [
-        { logo_id: testLogoId, type: "brand", value: "test-brand" },
-      ],
+      results: [{ logo_id: testLogoId, type: "brand", value: "test-brand" }],
     };
     fetchMock.mockResolvedValue(mockResponse(mockData));
 
@@ -65,7 +63,6 @@ describe("Robotoff", () => {
       type: "brand",
       value: "test-brand",
     });
-
   }, 15000);
 
   it("resets a logo", async () => {
@@ -75,6 +72,5 @@ describe("Robotoff", () => {
 
     expect(res.error).toBeUndefined();
     expect(res.data).toBeUndefined();
-  
   });
 });

--- a/tests/robotoff.spec.ts
+++ b/tests/robotoff.spec.ts
@@ -48,7 +48,7 @@ describe("Robotoff", () => {
 
   it("gets logo annotations", async () => {
     const mockData = {
-      annotations: [
+      results: [
         { logo_id: testLogoId, type: "brand", value: "test-brand" },
       ],
     };
@@ -57,10 +57,10 @@ describe("Robotoff", () => {
     const res = await robotoff.getLogoAnnotations(testLogoId);
 
     expect(res.data).toBeDefined();
-    expect(Array.isArray(res.data?.annotations)).toBe(true);
-    expect(res.data!.annotations.length).toBe(1);
+    expect(Array.isArray(res.data?.results)).toBe(true);
+    expect(res.data!.results.length).toBe(1);
 
-    expect(res.data!.annotations[0]).toEqual({
+    expect(res.data!.results[0]).toEqual({
       logo_id: testLogoId,
       type: "brand",
       value: "test-brand",

--- a/tests/robotoff.spec.ts
+++ b/tests/robotoff.spec.ts
@@ -1,0 +1,53 @@
+import { Robotoff } from "../src";
+
+describe("Robotoff", () => {
+
+    const robotoff = new Robotoff(fetch as any);
+    let testLogoId: number;
+    it("searches logo crops", async () => {
+ 
+        const res = await robotoff.searchLogos({
+          barcode: "5410041040807",
+          count: 2,
+        });
+ 
+        expect(res.data).toBeDefined();
+        expect(res.data?.logos).toBeDefined();
+        expect(res.data!.logos.length).toBeGreaterThan(0);
+        testLogoId = res.data!.logos[0].id as number;
+    });
+    it("annotates a logo", async () => {
+        const annotations: {
+            logo_id: number;
+            type: "brand" | "category" | "label" | "no_logo" | "nutritional_label" | "packager_code" | "packaging" | "qr_code" | "store";
+            value: string | null;
+            server_type?: "off" | "obf" | "opff" | "opf" | "off_pro";
+          }[] = [
+            {
+              logo_id: testLogoId,
+              type: "brand",
+              value: "test-brand",
+              server_type: "off",
+            },
+        ];
+
+        const res = await robotoff.annotateLogos(annotations);
+        expect(res).toBeDefined();
+    });
+
+
+    it("gets logo annotations", async () => {
+        const res = await robotoff.getLogoAnnotations(testLogoId);
+
+        expect(res.data).toBeDefined();
+        expect(Array.isArray(res.data?.annotations || [])).toBe(true);
+    
+    }, 15000);
+
+    it("resets a logo", async () => {
+        const res = await robotoff.resetLogo(testLogoId);
+    
+        expect(res).toBeDefined();
+    });
+
+});


### PR DESCRIPTION
### What
Implemented logos & labels related functions
Added functions:
- `searchLogos(params):` Fetch logo crops based on barcode, type, and other filters.
- `annotateLogos(annotations):` Annotate logos with type and value.
- `resetLogo(logoId):` Reset a specific logo to remove annotations.
- `getLogoAnnotations(logoId, index, count):` Retrieve annotations for a logo or globally.

### Screenshot
![Robotoff_logos](https://github.com/user-attachments/assets/8f1246e9-4891-4d17-96b8-a57512a8f34a)

### Part of 
- #528
