### PR TITLE
feat: added getStats method for nutripatrol

### DIFF
--- a/src/nutripatrol.ts
+++ b/src/nutripatrol.ts
@@ -8,6 +8,7 @@ export type FlagCreate = components["schemas"]["FlagCreate"];
 export type Flag = components["schemas"]["Flag"];
 export type Ticket = components["schemas"]["Ticket"];
 export type TicketStatus = components["schemas"]["TicketStatus"];
+export type StatsResponse = components["schemas"]["StatsResponse"];
 
 export class NutriPatrol {
   private readonly fetch: typeof global.fetch;
@@ -135,6 +136,28 @@ export class NutriPatrol {
         path: { ticket_id: ticketId },
         query: { status },
       },
+    });
+  }
+
+  /**
+   * Get ticket statistics for the last N days.
+   *
+   * Returns the total number of tickets, broken down by status, flavor, and type,
+   * along with the date range of the data.
+   *
+   * @param {number} [nDays] - Number of days to fetch stats for (defaults to 31 on the server).
+   * @returns A promise that resolves with the stats data or error.
+   * @example
+   * const { data, error } = await nutripatrol.getStats();
+   * if (data) console.log("Total tickets:", data.total_tickets);
+   *
+   * @example
+   * // Get stats for the last 7 days
+   * const { data } = await nutripatrol.getStats(7);
+   */
+  getStats(nDays?: number) {
+    return this.client.GET("/api/v1/stats", {
+      params: { query: { n_days: nDays } },
     });
   }
 

--- a/tests/nutripatrol.spec.ts
+++ b/tests/nutripatrol.spec.ts
@@ -223,6 +223,50 @@ describe("NutriPatrol Wrapper", () => {
     });
   });
 
+  describe("Stats", () => {
+    it("should fetch stats successfully", async () => {
+      const mockData = {
+        total_tickets: 100,
+        tickets_by_status: { open: 60, closed: 40 },
+        tickets_by_flavor: { off: 80, obf: 20 },
+        tickets_by_type: { product: 50, image: 50 },
+        n_days: 31,
+        start_date: "2026-01-23T00:00:00",
+        end_date: "2026-02-23T00:00:00",
+      };
+      fetchMock.mockResolvedValue(mockResponse(mockData));
+
+      const { data, error } = await client.getStats();
+      expect(data).toEqual(mockData);
+      expect(error).toBeUndefined();
+    });
+
+    it("should fetch stats with custom nDays", async () => {
+      const mockData = {
+        total_tickets: 10,
+        tickets_by_status: { open: 7, closed: 3 },
+        tickets_by_flavor: { off: 10 },
+        tickets_by_type: { image: 10 },
+        n_days: 7,
+        start_date: "2026-02-16T00:00:00",
+        end_date: "2026-02-23T00:00:00",
+      };
+      fetchMock.mockResolvedValue(mockResponse(mockData));
+
+      const { data, error } = await client.getStats(7);
+      expect(data).toEqual(mockData);
+      expect(error).toBeUndefined();
+    });
+
+    it("should handle error when fetching stats", async () => {
+      fetchMock.mockResolvedValue(mockResponse(null, false, 500));
+
+      const { data, error } = await client.getStats();
+      expect(data).toBeUndefined();
+      expect(error).toBeDefined();
+    });
+  });
+
   describe("API Status", () => {
     it("should return data when API is up", async () => {
       const mockData = { status: "ok" };


### PR DESCRIPTION
### What
- Added the `getStats` method for nutripatrol as per the swagger
- Along with it added 3 tests: `should fetch stats successfully`, `should fetch stats with custom nDays`, `should handle error when fetching stats`

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
<img width="648" height="455" alt="image" src="https://github.com/user-attachments/assets/d1c9dcc8-9993-4264-a703-7baf19db41f8" />


### Part of 
#613 
