### PR TITLE
ci: add NODE_AUTH_TOKEN to npm publish workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,3 +67,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --tag ${{ github.event.inputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What
Added the `NPM_TOKEN` secret as the `NODE_AUTH_TOKEN` environment variable to the publish step

@VaiTon this would require `NPM_TOKEN` secret to this particular repo


### Part of 
#443 
