### PR TITLE
feat: add support for structured packaging data (V3)

### DIFF
--- a/src/off-v3.ts
+++ b/src/off-v3.ts
@@ -46,7 +46,6 @@ export type ProductDataSection = {
 export type ProductDataType = ProductDataSection & {
   knowledge_panels: Record<string, KnowledgePanel>;
   product_name: string;
-  [lang: LangProduct]: string;
   _id: string;
   code: string;
   _keywords: string[];
@@ -64,7 +63,6 @@ export type ProductDataType = ProductDataSection & {
   additives_tags: string[];
 
   ingredients_text: string;
-  [lang: LangIngredient]: string;
 
   image_front_url: string;
   image_front_small_url: string;
@@ -86,8 +84,7 @@ export type ProductDataType = ProductDataSection & {
   nova_group: number;
 
   packaging: string;
-  packaging_text: string;
-  [lang: LangPackagingText]: string;
+  packaging_text?: string;
   packagings?: PackagingComponent[];
   packagings_complete?: number;
   manufacturing_places: string;
@@ -137,7 +134,7 @@ export type ProductDataType = ProductDataSection & {
     [lang: string]: number;
   };
   lang: string;
-};
+} & Partial<Record<LangProduct | LangIngredient | LangPackagingText, string>>;
 
 export type ProductStateBase = {
   result: {

--- a/src/off-v3.ts
+++ b/src/off-v3.ts
@@ -10,6 +10,8 @@ import type {
 
 export type ResponseStatus = components["schemas"]["response_status"];
 export type Product = components["schemas"]["product_v3"];
+export type PackagingComponent = components["schemas"]["packaging_component"];
+export type PackagingTaxonomyTag = components["schemas"]["shape"];
 
 export type ProductImageUploadParams = NonNullable<
   operations["post-api-v3-product-code-images"]["requestBody"]
@@ -17,6 +19,10 @@ export type ProductImageUploadParams = NonNullable<
 
 export type ProductQuery = NonNullable<
   operations["get-api-v3-product-code"]["parameters"]["query"]
+>;
+
+export type TaxonomySuggestionsQuery = NonNullable<
+  operations["get-api-v3-taxonomy_suggestions-taxonomy"]["parameters"]["query"]
 >;
 
 export type ImageSelectionData = NonNullable<
@@ -79,6 +85,8 @@ export type ProductDataType = ProductDataSection & {
   nova_group: number;
 
   packaging: string;
+  packagings?: PackagingComponent[];
+  packagings_complete?: number;
   manufacturing_places: string;
 
   brands: string;
@@ -201,6 +209,16 @@ export class ProductOpenerApiV3 {
     return await this.client.PATCH("/api/v3/product/{code}", {
       params: { path: { code: barcode } },
       body: { fields: "updated", product: { images } },
+    });
+  }
+
+  /**
+   * Fetch taxonomy suggestions for autocomplete
+   * @param query - Suggestion query parameters
+   */
+  async getTaxonomySuggestions(query: TaxonomySuggestionsQuery) {
+    return this.client.GET("/api/v3/taxonomy_suggestions", {
+      params: { query },
     });
   }
 

--- a/src/off-v3.ts
+++ b/src/off-v3.ts
@@ -4,6 +4,7 @@ import type { KnowledgePanel } from "./knowledgepanels.js";
 import type {
   LangIngredient,
   LangProduct,
+  LangPackagingText,
   RawImage,
   SelectedImage,
 } from "./types.js";
@@ -85,6 +86,8 @@ export type ProductDataType = ProductDataSection & {
   nova_group: number;
 
   packaging: string;
+  packaging_text: string;
+  [lang: LangPackagingText]: string;
   packagings?: PackagingComponent[];
   packagings_complete?: number;
   manufacturing_places: string;

--- a/src/off.ts
+++ b/src/off.ts
@@ -68,6 +68,9 @@ import type {
   Product as ProductV3,
   ProductState as ProductStateV3,
   ResponseStatus as ResponseStatusV3,
+  PackagingComponent,
+  PackagingTaxonomyTag,
+  TaxonomySuggestionsQuery,
 } from "./off-v3.js";
 export type {
   ProductDataType,
@@ -77,6 +80,9 @@ export type {
   ProductV3,
   ProductStateV3,
   ResponseStatusV3,
+  PackagingComponent,
+  PackagingTaxonomyTag,
+  TaxonomySuggestionsQuery,
 };
 
 import { VERSION } from "./version.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type LangIngredient = `ingredients_text_${string}`;
 export type LangProduct = `product_name_${string}`;
+export type LangPackagingText = `packaging_text_${string}`;
 
 export type ImageSize = { h: number; w: number };
 


### PR DESCRIPTION
### What
This updates the V3 API definitions to support structured packaging components.
Specifically I added:
- Types: `PackagingComponent` and `PackagingTaxonomyTag `(shapes, materials, recycling)
- Product Updates: Added `packagings ` and `packagings_complete ` fields to the V3 Product model
- Added a new method `getTaxonomySuggestions()` to _ProductOpenerApiV3_ to facilitate fetching autocomplete suggestions from the taxonomy API.

These SDK changes will provide the necessary type safety and API wrappers to read, suggest, and submit this structured data via the V3 API


### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/764