### PR TITLE
fix: packaging field as optional

### DIFF
--- a/src/off-v3.ts
+++ b/src/off-v3.ts
@@ -83,7 +83,7 @@ export type ProductDataType = ProductDataSection & {
   ecoscore_grade: string;
   nova_group: number;
 
-  packaging: string;
+  packaging?: string;
   packaging_text?: string;
   packagings?: PackagingComponent[];
   packagings_complete?: number;


### PR DESCRIPTION
### What
Made packaging field as optional as per- https://github.com/openfoodfacts/openfoodfacts-explorer/pull/978 

### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/764
