### PR TITLE
feat: taxonomy based on product type

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -18,6 +18,13 @@ export const BACKEND_DOMAINS = {
   [BackendType.OPF]: "openproductsfacts.org",
 };
 
+export const STATIC_HOSTS = {
+  [BackendType.OFF]: `https://static.${BACKEND_DOMAINS[BackendType.OFF]}`,
+  [BackendType.OBF]: `https://static.${BACKEND_DOMAINS[BackendType.OBF]}`,
+  [BackendType.OPFF]: `https://static.${BACKEND_DOMAINS[BackendType.OPFF]}`,
+  [BackendType.OPF]: `https://static.${BACKEND_DOMAINS[BackendType.OPF]}`,
+};
+
 export const BACKEND_NAMES = {
   [BackendType.OFF]: "OpenFoodFacts",
   [BackendType.OBF]: "OpenBeautyFacts",

--- a/src/off.ts
+++ b/src/off.ts
@@ -373,7 +373,7 @@ export class OpenFoodFacts {
   }
 
   async getTaxo<T extends TaxoNode>(taxo: string): Promise<Taxonomy<T>> {
-    const res = await this.fetch(TAXONOMY_URL(taxo));
+    const res = await this.fetch(TAXONOMY_URL(taxo, this.backendType));
     return (await res.json()) as Taxonomy<T>;
   }
 

--- a/src/taxonomy/api.ts
+++ b/src/taxonomy/api.ts
@@ -1,4 +1,6 @@
-import { STATIC_HOST } from "../consts.js";
+import { STATIC_HOSTS, BackendType } from "../consts.js";
 
-export const TAXONOMY_URL = (taxo: string) =>
-  `${STATIC_HOST}/data/taxonomies/${taxo}.json`;
+export const TAXONOMY_URL = (
+  taxo: string,
+  type: BackendType = BackendType.OFF,
+) => `${STATIC_HOSTS[type]}/data/taxonomies/${taxo}.json`;


### PR DESCRIPTION
### What
Currently, the SDK hardcodes static.openfoodfacts.org for all taxonomy requests. In this PR we made taxonomy loading backend-aware by using the correct static host based on the configured BackendType (OFF, OBF, OPFF, or OPF).

### Fixes bug(s)
- <!-- #1, #2 and #3 (change by appropriate issues) -->

### Part of 
- https://github.com/openfoodfacts/openfoodfacts-explorer/issues/638
