### PR TITLE
fix: remove duplicate 'last_modified_t' from FACETS_SORT_OPTIONS

### DIFF
--- a/src/facets.ts
+++ b/src/facets.ts
@@ -5,7 +5,6 @@ export const FACETS_SORT_OPTIONS = [
   "popularity",
   "environmental_score_score",
   "created_t",
-  "last_modified_t",
 ] as const;
 
 export type FacetSortOption = (typeof FACETS_SORT_OPTIONS)[number];


### PR DESCRIPTION
## 🔗 Related Issue
Fixes #793 

## 📝 Changes Made
- Removed duplicate `"last_modified_t"` entry from `FACETS_SORT_OPTIONS` constant in `src/facets.ts`

## ✅ Testing
- [x] All existing tests pass (141/141)
- [x] Build succeeds without errors
- [x] No linting issues

## 📸 Before & After

**Before:**
```typescript
export const FACETS_SORT_OPTIONS = [
  "last_modified_t",
  "popularity",
  "environmental_score_score",
  "created_t",
  "last_modified_t",  // 👈 duplicate
] as const;

**After:**
export const FACETS_SORT_OPTIONS = [
  "last_modified_t",
  "popularity",
  "environmental_score_score",
  "created_t",
] as const;