### PR TITLE
feat: added knowledge pannels

### DIFF
--- a/src/knowledgepanels.ts
+++ b/src/knowledgepanels.ts
@@ -1,3 +1,5 @@
+export type KnowledgePanels = { [key: string]: KnowledgePanel };
+
 export type KnowledgePanelTitle = {
   title: string;
   subtitle?: string;


### PR DESCRIPTION
### What
Added KnowledgePanels type 
```export type KnowledgePanels = { [key: string]: KnowledgePanel };```
This was missing from the SDK, causing clients to either define it locally.

### Part Of
#788 

Also its better we keep types looser, and can extend it in client.