### PR TITLE
feat: corrected facet handling logic

### DIFF
--- a/src/facets.ts
+++ b/src/facets.ts
@@ -5,8 +5,6 @@ export const FACETS_SORT_OPTIONS = [
   "popularity",
   "environmental_score_score",
   "created_t",
-  "last_modified_t",
-  "nutriscore_score",
 ] as const;
 
 export type FacetSortOption = (typeof FACETS_SORT_OPTIONS)[number];


### PR DESCRIPTION
## PR Summary

### Changes Made
This PR removes two invalid sort options from the `FACETS_SORT_OPTIONS` array in `src/facets.ts`:

- `last_modified_t`
- `nutriscore_score`

### Modified File
`src/facets.ts`

```ts
export const FACETS_SORT_OPTIONS = [
  "popularity",
  "environmental_score_score",
  "created_t",
] as const;
```

### Type of Change
- Bug fix – removes unsupported facet sort options

### Rationale
The removed sort options (`last_modified_t` and `nutriscore_score`) appear to be invalid or unsupported by the backend API for facet sorting. Keeping them exposed in the SDK could lead to errors when users attempt to sort using these fields.

Removing them ensures that only valid sort options are available, improving reliability and preventing incorrect API usage.