### PR TITLE
feat: refactored knowledge Pannel Structure

### DIFF
--- a/src/knowledgepanels.ts
+++ b/src/knowledgepanels.ts
@@ -1,6 +1,6 @@
 export type KnowledgePanels = { [key: string]: KnowledgePanel };
 
-export type KnowledgePanelTitleBase  = {
+export type KnowledgePanelTitleBase = {
   title: string;
   subtitle?: string;
   icon_url: string;
@@ -10,12 +10,12 @@ export type KnowledgePanelTitleBase  = {
 };
 
 type KnowledgePanelTitleGrade = KnowledgePanelTitleBase & {
-  type: 'grade';
-  grade: 'a' | 'b' | 'c' | 'd' | 'e' | 'unknown';
+  type: "grade";
+  grade: "a" | "b" | "c" | "d" | "e" | "unknown";
 };
 
 type KnowledgePanelTitlePercentage = KnowledgePanelTitleBase & {
-  type: 'percentage';
+  type: "percentage";
   value: number;
 };
 

--- a/src/knowledgepanels.ts
+++ b/src/knowledgepanels.ts
@@ -29,6 +29,8 @@ export type KnowledgePanel = {
   type: "card" | "inline";
   expanded: boolean;
   expand_for: string;
+  evaluation?: string;
+  half_width_on_mobile?: boolean;
   title_element: KnowledgePanelTitle;
   elements: KnowledgeElement[];
   topics: string[];

--- a/src/knowledgepanels.ts
+++ b/src/knowledgepanels.ts
@@ -1,14 +1,27 @@
 export type KnowledgePanels = { [key: string]: KnowledgePanel };
 
-export type KnowledgePanelTitle = {
+export type KnowledgePanelTitleBase  = {
   title: string;
   subtitle?: string;
-  grade: "a" | "b" | "c" | "d" | "e" | "unknown";
   icon_url: string;
-  icon_color_from_evaluation: string;
+  icon_color_from_evaluation: boolean;
   icon_size: string;
-  type: string;
+  type?: never;
 };
+type KnowledgePanelTitleGrade = KnowledgePanelTitleBase & {
+  type: 'grade';
+  grade: 'a' | 'b' | 'c' | 'd' | 'e' | 'unknown';
+};
+
+type KnowledgePanelTitlePercentage = KnowledgePanelTitleBase & {
+  type: 'percentage';
+  value: number;
+};
+
+export type KnowledgePanelTitle =
+  | KnowledgePanelTitleGrade
+  | KnowledgePanelTitlePercentage
+  | KnowledgePanelTitleBase;
 
 export type KnowledgePanelSize = "small";
 

--- a/src/knowledgepanels.ts
+++ b/src/knowledgepanels.ts
@@ -8,6 +8,7 @@ export type KnowledgePanelTitleBase  = {
   icon_size: string;
   type?: never;
 };
+
 type KnowledgePanelTitleGrade = KnowledgePanelTitleBase & {
   type: 'grade';
   grade: 'a' | 'b' | 'c' | 'd' | 'e' | 'unknown';


### PR DESCRIPTION
### What
- I have changed the structure a bit based on the response. Took some help from explorer knowledge pannel itself.
- Also I added  : ```evaluation?: string;
  half_width_on_mobile?: boolean;``` inside `KnowledgePanel` as it was missing and API is returning it in response.

### Part Off
- #788 