### PR TITLE
test: add network failure test for SearchApi

### DIFF
--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -101,6 +101,20 @@ describe("SearchApi Wrapper", () => {
       expect(result.error).toBeDefined();
       expect(result.response.status).toBe(400);
     });
+
+    it("should handle network failure when performing search", async () => {
+      const body = {
+        q: "test",
+        langs: ["en"],
+        page_size: 20,
+        page: 1,
+      };
+      fetchMock.mockRejectedValue(new Error("Network error"));
+
+      await expect(client.search(body)).rejects.toThrow("Network error");
+    });  
+     
+      
   });
 
   describe("Autocomplete", () => {


### PR DESCRIPTION

### What

This PR adds a test case for the scenario where the network request fails before a response is received.

While reviewing `tests/search.spec.ts`, I noticed that the existing tests cover:
- successful search responses
- HTTP error responses (e.g. 400)

However, there was no test covering the case where `fetch` itself rejects due to a network failure.

This PR adds a test that mocks a rejected `fetch` call and verifies that `SearchApi.search()` correctly propagates the error.

### Changes
- Added a test case in `tests/search.spec.ts` for network failure during search
- Used `fetchMock.mockRejectedValue()` to simulate the failure

### Result
All tests pass locally after adding the new test.

Fixes #809