### PR TITLE
feat: add support for /api/v3/current-user/permissions endpoint

### DIFF
--- a/src/off.ts
+++ b/src/off.ts
@@ -575,10 +575,7 @@ export class OpenFoodFacts {
    * Requires a valid access token (set via constructor options).
    * @returns User permissions including moderator/admin flags, or error details
    */
-  async getCurrentUserPermissions(): Promise<
-    | { data: CurrentUserPermissions; error?: undefined }
-    | { data?: undefined; error: string }
-  > {
+  async getCurrentUserPermissions() {
     const response = await this.fetch(
       new URL("/api/v3/current-user/permissions", this.baseUrl),
     );

--- a/src/off.ts
+++ b/src/off.ts
@@ -576,6 +576,7 @@ export class OpenFoodFacts {
    * @returns User permissions including moderator/admin flags, or error details
    */
   async getCurrentUserPermissions() {
+    // TODO: use auto-generated openapi types when they become available
     const response = await this.fetch(
       new URL("/api/v3/current-user/permissions", this.baseUrl),
     );

--- a/src/off.ts
+++ b/src/off.ts
@@ -569,6 +569,25 @@ export class OpenFoodFacts {
     }
     return { data: (await response.json()) as LoginStatus };
   }
+
+  /**
+   * Returns the current authenticated user's permissions.
+   * Requires a valid access token (set via constructor options).
+   * @returns User permissions including moderator/admin flags, or error details
+   */
+  async getCurrentUserPermissions(): Promise<
+    | { data: CurrentUserPermissions; error?: undefined }
+    | { data?: undefined; error: string }
+  > {
+    const response = await this.fetch(
+      new URL("/api/v3/current-user/permissions", this.baseUrl),
+    );
+
+    if (!response.ok) {
+      return { error: `HTTP error! status: ${response.status}` };
+    }
+    return { data: (await response.json()) as CurrentUserPermissions };
+  }
 }
 
 type BaseLoginStatus = { status: 0 | 1; status_verbose: string };
@@ -580,6 +599,21 @@ type LoggedInStatus = BaseLoginStatus & {
 };
 
 export type LoginStatus = LoggedInStatus | LoggedOutStatus;
+
+export type CurrentUserPermissions = {
+  status: "success" | "failure";
+  result?: { id: string };
+  user?: {
+    userid: string;
+    name: string;
+    moderator: 0 | 1;
+    admin: 0 | 1;
+  };
+  errors?: Array<{
+    message?: { id: string };
+    impact?: { id: string };
+  }>;
+};
 
 export type ProductSearch<T = ProductDataType> = {
   count: number;

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -599,4 +599,64 @@ describe("OpenFoodFacts", () => {
       );
     });
   });
+
+  describe("getCurrentUserPermissions", () => {
+    it("should return user permissions when authenticated", async () => {
+      const mockData = {
+        status: "success",
+        result: { id: "user_found" },
+        user: {
+          userid: "stephane",
+          name: "Stephane Gigandet",
+          moderator: 1,
+          admin: 1,
+        },
+      };
+
+      mockFetchSuccess(mockData);
+
+      const result = await productsApi.getCurrentUserPermissions();
+
+      expect(result.error).toBeUndefined();
+      expect(result.data).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        new URL(
+          "/api/v3/current-user/permissions",
+          "https://world.openfoodfacts.org",
+        ),
+        expect.anything(),
+      );
+    });
+
+    it("should return error when not authenticated (401)", async () => {
+      mockFetch.mockResolvedValue(
+        TestUtils.mockResponse(
+          {
+            status: "failure",
+            errors: [
+              {
+                message: { id: "authentication_required" },
+                impact: { id: "failure" },
+              },
+            ],
+          },
+          false,
+          401,
+        ),
+      );
+
+      const result = await productsApi.getCurrentUserPermissions();
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBe("HTTP error! status: 401");
+    });
+
+    it("should throw on network error", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      await expect(productsApi.getCurrentUserPermissions()).rejects.toThrow(
+        "Network error",
+      );
+    });
+  });
 });


### PR DESCRIPTION
### What
Client applications (like the Explorer) needs to know if the currently authenticated user has privileges (like `admin` or `moderator` roles). Previously, there was no standard API endpoint to retrieve this specific role information for the current user.

So, to solve this, a new GET endpoint `/api/v3/current-user/permissions`  was added to the main(server) codebase: https://github.com/openfoodfacts/openfoodfacts-server/pull/13205

By creating this endpoint, the frontend can now take its Keycloak token, hand it to the off-server, and securely retrieve the `moderator: 1` or `admin: 1` flags directly from the `.sto`(user storage) files on the backend(server).  
It returns a 401 Unauthorized if the user is not authenticated, and correctly handles invalid sub-actions with a 404 Not Found.

### Fixes bug(s)
#615 

