### PR TITLE
ci: fix automatic npm publication using OIDC

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,13 +37,13 @@ jobs:
       id-token: write
 
     # only publish from tags
-    if: startsWith(github.event.inputs.git_ref, 'refs/tags/')
+    if: startsWith(inputs.git_ref, 'refs/tags/')
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.git_ref }}
+          ref: ${{ inputs.git_ref }}
 
       - name: Setup Node.js and .npmrc
         uses: actions/setup-node@v6
@@ -66,4 +66,4 @@ jobs:
         run: yarn test
 
       - name: Publish to npm
-        run: npm publish --tag ${{ github.event.inputs.tag }}
+        run: npm publish --tag ${{ inputs.tag }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,4 +66,6 @@ jobs:
         run: yarn test
 
       - name: Publish to npm
-        run: npm publish --tag ${{ inputs.tag }}
+        env:
+          NPM_TAG: ${{ inputs.tag }}
+        run: npm publish --tag $NPM_TAG

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,14 +4,15 @@ on:
     branches:
       - develop
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write # Added to allow OIDC token generation
+
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write # Added to allow OIDC token generation
 
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # Added to allow OIDC token generation
 
 jobs:
   release-please:


### PR DESCRIPTION
Fixes #443 

### Description
This PR resolves the issue preventing automatic publication to npm via Trusted Publishers (OIDC). 

**Changes made:**
1. Updated `.github/workflows/package.yml` to use the `inputs` context instead of `github.event.inputs`. This ensures the inputs are correctly resolved when the workflow is called via `workflow_call` by the `release-please.yml` workflow.
2. Added `id-token: write` to the top-level permissions in `.github/workflows/release-please.yml` so the caller workflow has the authority to facilitate the OIDC handshake.

**Note to Maintainers:**
For this to work entirely, an organization admin must configure Trusted Publishing on npmjs.com for the `@openfoodfacts/openfoodfacts-nodejs` package, linking it to the `openfoodfacts-js` repository and the `release-please.yml` workflow file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to fix tag-based publish behavior and use workflow inputs for runtime parameters when publishing.
  * Adjusted workflow job permissions, moving permission scope to job level and granting identity token write access for release automation while preserving existing content/publish permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->