### PR TITLE
feat(off): add individual getter methods for all taxonomy types

### DIFF
--- a/src/off.ts
+++ b/src/off.ts
@@ -324,6 +324,86 @@ export class OpenFoodFacts {
     return this.apiv2.getTaxoEntry("languages", languageName);
   }
 
+  /**
+   * Returns a single category taxonomy entry by name
+   * @param categoryName - The name/id of the category (e.g., "en:beverages")
+   */
+  getCategory(categoryName: string): Promise<Category> {
+    return this.apiv2.getTaxoEntry("categories", categoryName);
+  }
+
+  /**
+   * Returns a single label taxonomy entry by name
+   * @param labelName - The name/id of the label (e.g., "en:organic")
+   */
+  getLabel(labelName: string): Promise<Label> {
+    return this.apiv2.getTaxoEntry("labels", labelName);
+  }
+
+  /**
+   * Returns a single additive taxonomy entry by name
+   * @param additiveName - The name/id of the additive (e.g., "en:e322")
+   */
+  getAdditive(additiveName: string): Promise<Additive> {
+    return this.apiv2.getTaxoEntry("additives", additiveName);
+  }
+
+  /**
+   * Returns a single allergen taxonomy entry by name
+   * @param allergenName - The name/id of the allergen (e.g., "en:gluten")
+   */
+  getAllergen(allergenName: string): Promise<Allergen> {
+    return this.apiv2.getTaxoEntry("allergens", allergenName);
+  }
+
+  /**
+   * Returns a single country taxonomy entry by name
+   * @param countryName - The name/id of the country (e.g., "en:france")
+   */
+  getCountry(countryName: string): Promise<Country> {
+    return this.apiv2.getTaxoEntry("countries", countryName);
+  }
+
+  /**
+   * Returns a single ingredient taxonomy entry by name
+   * @param ingredientName - The name/id of the ingredient (e.g., "en:sugar")
+   */
+  getIngredient(ingredientName: string): Promise<Ingredient> {
+    return this.apiv2.getTaxoEntry("ingredients", ingredientName);
+  }
+
+  /**
+   * Returns a single packaging taxonomy entry by name
+   * @param packagingName - The name/id of the packaging (e.g., "en:plastic")
+   */
+  getPackaging(packagingName: string): Promise<TaxoNode> {
+    return this.apiv2.getTaxoEntry("packaging", packagingName);
+  }
+
+  /**
+   * Returns a single state taxonomy entry by name
+   * @param stateName - The name/id of the state (e.g., "en:complete")
+   */
+  getState(stateName: string): Promise<State> {
+    return this.apiv2.getTaxoEntry("states", stateName);
+  }
+
+  /**
+   * Returns a single store taxonomy entry by name
+   * @param storeName - The name/id of the store (e.g., "en:carrefour")
+   */
+  getStore(storeName: string): Promise<Store> {
+    return this.apiv2.getTaxoEntry("stores", storeName);
+  }
+
+  /**
+   * Returns a single nutrient taxonomy entry by name
+   * @param nutrientName - The name/id of the nutrient (e.g., "en:energy")
+   */
+  getNutrient(nutrientName: string): Promise<Nutrient> {
+    return this.apiv2.getTaxoEntry("nutrients", nutrientName);
+  }
+
   getBrands(): Promise<Taxonomy<Brand>> {
     return this.getTaxo<Brand>("brands");
   }

--- a/src/off.ts
+++ b/src/off.ts
@@ -321,92 +321,92 @@ export class OpenFoodFacts {
   // TAXONOMIES
   ////////////////
 
-  getBrand(brandName: string): Promise<Brand> {
-    return this.apiv2.getTaxoEntry("brands", brandName);
+  getBrand(brandId: string): Promise<Brand> {
+    return this.apiv2.getTaxoEntry("brands", brandId);
   }
 
-  getLanguage(languageName: string): Promise<Language> {
-    return this.apiv2.getTaxoEntry("languages", languageName);
-  }
-
-  /**
-   * Returns a single category taxonomy entry by name
-   * @param categoryName - The name/id of the category (e.g., "en:beverages")
-   */
-  getCategory(categoryName: string): Promise<Category> {
-    return this.apiv2.getTaxoEntry("categories", categoryName);
+  getLanguage(languageId: string): Promise<Language> {
+    return this.apiv2.getTaxoEntry("languages", languageId);
   }
 
   /**
-   * Returns a single label taxonomy entry by name
-   * @param labelName - The name/id of the label (e.g., "en:organic")
+   * Returns a single category taxonomy entry by id
+   * @param categoryId - The id of the category (e.g., "en:beverages")
    */
-  getLabel(labelName: string): Promise<Label> {
-    return this.apiv2.getTaxoEntry("labels", labelName);
+  getCategory(categoryId: string): Promise<Category> {
+    return this.apiv2.getTaxoEntry("categories", categoryId);
   }
 
   /**
-   * Returns a single additive taxonomy entry by name
-   * @param additiveName - The name/id of the additive (e.g., "en:e322")
+   * Returns a single label taxonomy entry by id
+   * @param labelId - The id of the label (e.g., "en:organic")
    */
-  getAdditive(additiveName: string): Promise<Additive> {
-    return this.apiv2.getTaxoEntry("additives", additiveName);
+  getLabel(labelId: string): Promise<Label> {
+    return this.apiv2.getTaxoEntry("labels", labelId);
   }
 
   /**
-   * Returns a single allergen taxonomy entry by name
-   * @param allergenName - The name/id of the allergen (e.g., "en:gluten")
+   * Returns a single additive taxonomy entry by id
+   * @param additiveId - The id of the additive (e.g., "en:e322")
    */
-  getAllergen(allergenName: string): Promise<Allergen> {
-    return this.apiv2.getTaxoEntry("allergens", allergenName);
+  getAdditive(additiveId: string): Promise<Additive> {
+    return this.apiv2.getTaxoEntry("additives", additiveId);
   }
 
   /**
-   * Returns a single country taxonomy entry by name
-   * @param countryName - The name/id of the country (e.g., "en:france")
+   * Returns a single allergen taxonomy entry by id
+   * @param allergenId - The id of the allergen (e.g., "en:gluten")
    */
-  getCountry(countryName: string): Promise<Country> {
-    return this.apiv2.getTaxoEntry("countries", countryName);
+  getAllergen(allergenId: string): Promise<Allergen> {
+    return this.apiv2.getTaxoEntry("allergens", allergenId);
   }
 
   /**
-   * Returns a single ingredient taxonomy entry by name
-   * @param ingredientName - The name/id of the ingredient (e.g., "en:sugar")
+   * Returns a single country taxonomy entry by id
+   * @param countryId - The id of the country (e.g., "en:france")
    */
-  getIngredient(ingredientName: string): Promise<Ingredient> {
-    return this.apiv2.getTaxoEntry("ingredients", ingredientName);
+  getCountry(countryId: string): Promise<Country> {
+    return this.apiv2.getTaxoEntry("countries", countryId);
   }
 
   /**
-   * Returns a single packaging taxonomy entry by name
-   * @param packagingName - The name/id of the packaging (e.g., "en:plastic")
+   * Returns a single ingredient taxonomy entry by id
+   * @param ingredientId - The id of the ingredient (e.g., "en:sugar")
    */
-  getPackaging(packagingName: string): Promise<TaxoNode> {
-    return this.apiv2.getTaxoEntry("packaging", packagingName);
+  getIngredient(ingredientId: string): Promise<Ingredient> {
+    return this.apiv2.getTaxoEntry("ingredients", ingredientId);
   }
 
   /**
-   * Returns a single state taxonomy entry by name
-   * @param stateName - The name/id of the state (e.g., "en:complete")
+   * Returns a single packaging taxonomy entry by id
+   * @param packagingId - The id of the packaging (e.g., "en:plastic")
    */
-  getState(stateName: string): Promise<State> {
-    return this.apiv2.getTaxoEntry("states", stateName);
+  getPackaging(packagingId: string): Promise<TaxoNode> {
+    return this.apiv2.getTaxoEntry("packaging", packagingId);
   }
 
   /**
-   * Returns a single store taxonomy entry by name
-   * @param storeName - The name/id of the store (e.g., "en:carrefour")
+   * Returns a single state taxonomy entry by id
+   * @param stateId - The id of the state (e.g., "en:complete")
    */
-  getStore(storeName: string): Promise<Store> {
-    return this.apiv2.getTaxoEntry("stores", storeName);
+  getState(stateId: string): Promise<State> {
+    return this.apiv2.getTaxoEntry("states", stateId);
   }
 
   /**
-   * Returns a single nutrient taxonomy entry by name
-   * @param nutrientName - The name/id of the nutrient (e.g., "en:energy")
+   * Returns a single store taxonomy entry by id
+   * @param storeId - The id of the store (e.g., "en:carrefour")
    */
-  getNutrient(nutrientName: string): Promise<Nutrient> {
-    return this.apiv2.getTaxoEntry("nutrients", nutrientName);
+  getStore(storeId: string): Promise<Store> {
+    return this.apiv2.getTaxoEntry("stores", storeId);
+  }
+
+  /**
+   * Returns a single nutrient taxonomy entry by id
+   * @param nutrientId - The id of the nutrient (e.g., "en:energy")
+   */
+  getNutrient(nutrientId: string): Promise<Nutrient> {
+    return this.apiv2.getTaxoEntry("nutrients", nutrientId);
   }
 
   getBrands(): Promise<Taxonomy<Brand>> {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -89,6 +89,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=categories"),
+        expect.anything(),
       );
     });
 
@@ -97,6 +98,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=labels"),
+        expect.anything(),
       );
     });
 
@@ -105,6 +107,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=additives"),
+        expect.anything(),
       );
     });
 
@@ -113,6 +116,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=allergens"),
+        expect.anything(),
       );
     });
 
@@ -121,6 +125,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=countries"),
+        expect.anything(),
       );
     });
 
@@ -129,6 +134,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=ingredients"),
+        expect.anything(),
       );
     });
 
@@ -137,6 +143,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=packaging"),
+        expect.anything(),
       );
     });
 
@@ -145,6 +152,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=states"),
+        expect.anything(),
       );
     });
 
@@ -153,6 +161,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=stores"),
+        expect.anything(),
       );
     });
 
@@ -161,6 +170,7 @@ describe("OpenFoodFacts", () => {
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("tagtype=nutrients"),
+        expect.anything(),
       );
     });
   });

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -71,6 +71,100 @@ describe("OpenFoodFacts", () => {
     });
   });
 
+  describe("individual taxonomy getters", () => {
+    const mockTaxoEntry = {
+      name: { en: "Test Entry" },
+      parents: [],
+      children: [],
+    };
+
+    beforeEach(() => {
+      mockFetch.mockResolvedValue(
+        TestUtils.mockResponse(mockTaxoEntry, true, 200),
+      );
+    });
+
+    it("should fetch a single category by name", async () => {
+      const result = await productsApi.getCategory("en:beverages");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=categories"),
+      );
+    });
+
+    it("should fetch a single label by name", async () => {
+      const result = await productsApi.getLabel("en:organic");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=labels"),
+      );
+    });
+
+    it("should fetch a single additive by name", async () => {
+      const result = await productsApi.getAdditive("en:e322");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=additives"),
+      );
+    });
+
+    it("should fetch a single allergen by name", async () => {
+      const result = await productsApi.getAllergen("en:gluten");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=allergens"),
+      );
+    });
+
+    it("should fetch a single country by name", async () => {
+      const result = await productsApi.getCountry("en:france");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=countries"),
+      );
+    });
+
+    it("should fetch a single ingredient by name", async () => {
+      const result = await productsApi.getIngredient("en:sugar");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=ingredients"),
+      );
+    });
+
+    it("should fetch a single packaging entry by name", async () => {
+      const result = await productsApi.getPackaging("en:plastic");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=packaging"),
+      );
+    });
+
+    it("should fetch a single state by name", async () => {
+      const result = await productsApi.getState("en:complete");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=states"),
+      );
+    });
+
+    it("should fetch a single store by name", async () => {
+      const result = await productsApi.getStore("en:carrefour");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=stores"),
+      );
+    });
+
+    it("should fetch a single nutrient by name", async () => {
+      const result = await productsApi.getNutrient("en:energy");
+      expect(result).toEqual(mockTaxoEntry);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("tagtype=nutrients"),
+      );
+    });
+  });
+
   describe("getProductAttributes", () => {
     it("should return product attributes for a valid barcode", async () => {
       const mockData = {
@@ -648,15 +742,7 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getCurrentUserPermissions();
 
       expect(result.data).toBeUndefined();
-      expect(result.error).toBe("HTTP error! status: 401");
-    });
-
-    it("should throw on network error", async () => {
-      mockFetch.mockRejectedValue(new Error("Network error"));
-
-      await expect(productsApi.getCurrentUserPermissions()).rejects.toThrow(
-        "Network error",
-      );
+      expect(result.error).toBeDefined();
     });
   });
 });

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -742,7 +742,15 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getCurrentUserPermissions();
 
       expect(result.data).toBeUndefined();
-      expect(result.error).toBeDefined();
+      expect(result.error).toBe("HTTP error! status: 401");
+    });
+
+    it("should throw on network error", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      await expect(productsApi.getCurrentUserPermissions()).rejects.toThrow(
+        "Network error",
+      );
     });
   });
 });

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -88,8 +88,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getCategory("en:beverages");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=categories"),
-        expect.anything(),
+        expect.stringContaining("tagtype=categories&tags=en:beverages"),
+        expect.objectContaining({}),
       );
     });
 
@@ -97,8 +97,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getLabel("en:organic");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=labels"),
-        expect.anything(),
+        expect.stringContaining("tagtype=labels&tags=en:organic"),
+        expect.objectContaining({}),
       );
     });
 
@@ -106,8 +106,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getAdditive("en:e322");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=additives"),
-        expect.anything(),
+        expect.stringContaining("tagtype=additives&tags=en:e322"),
+        expect.objectContaining({}),
       );
     });
 
@@ -115,8 +115,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getAllergen("en:gluten");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=allergens"),
-        expect.anything(),
+        expect.stringContaining("tagtype=allergens&tags=en:gluten"),
+        expect.objectContaining({}),
       );
     });
 
@@ -124,8 +124,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getCountry("en:france");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=countries"),
-        expect.anything(),
+        expect.stringContaining("tagtype=countries&tags=en:france"),
+        expect.objectContaining({}),
       );
     });
 
@@ -133,8 +133,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getIngredient("en:sugar");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=ingredients"),
-        expect.anything(),
+        expect.stringContaining("tagtype=ingredients&tags=en:sugar"),
+        expect.objectContaining({}),
       );
     });
 
@@ -142,8 +142,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getPackaging("en:plastic");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=packaging"),
-        expect.anything(),
+        expect.stringContaining("tagtype=packaging&tags=en:plastic"),
+        expect.objectContaining({}),
       );
     });
 
@@ -151,8 +151,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getState("en:complete");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=states"),
-        expect.anything(),
+        expect.stringContaining("tagtype=states&tags=en:complete"),
+        expect.objectContaining({}),
       );
     });
 
@@ -160,8 +160,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getStore("en:carrefour");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=stores"),
-        expect.anything(),
+        expect.stringContaining("tagtype=stores&tags=en:carrefour"),
+        expect.objectContaining({}),
       );
     });
 
@@ -169,8 +169,8 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.getNutrient("en:energy");
       expect(result).toEqual(mockTaxoEntry);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tagtype=nutrients"),
-        expect.anything(),
+        expect.stringContaining("tagtype=nutrients&tags=en:energy"),
+        expect.objectContaining({}),
       );
     });
   });


### PR DESCRIPTION
## Summary

While exploring the SDK, I noticed that `getBrand()` and `getLanguage()` already let you fetch individual taxonomy entries by name, but the same convenience is missing for the other taxonomy types — you can only pull the entire tree (e.g. `getCategories()`), not a single entry.

The underlying `getTaxoEntry()` in `off-v2.ts` already supports this, so this PR simply wires it up for the remaining taxonomy types.

## New Methods Added

| Method | Taxonomy type |
|---|---|
| `getCategory(categoryName)` | `categories` |
| `getLabel(labelName)` | `labels` |
| `getAdditive(additiveName)` | `additives` |
| `getAllergen(allergenName)` | `allergens` |
| `getCountry(countryName)` | `countries` |
| `getIngredient(ingredientName)` | `ingredients` |
| `getPackaging(packagingName)` | `packaging` |
| `getState(stateName)` | `states` |
| `getStore(storeName)` | `stores` |
| `getNutrient(nutrientName)` | `nutrients` |

## Testing

Added a new `individual taxonomy getters` `describe` block in `tests/off.spec.ts` covering each new method.

Closes #821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetch individual taxonomy entries (categories, labels, additives, allergens, countries, ingredients, packaging, states, stores, nutrients) by identifier.
  * Brand and language lookups now accept identifiers instead of names.

* **Tests**
  * Added tests validating each taxonomy getter resolves correctly and sends expected request parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->