### PR TITLE
fix: remove duplicate 'last_modified_t' from FACETS_SORT_OPTIONS

### DIFF
--- a/src/facets.ts
+++ b/src/facets.ts
@@ -5,7 +5,6 @@ export const FACETS_SORT_OPTIONS = [
   "popularity",
   "environmental_score_score",
   "created_t",
-  "last_modified_t",
   "nutriscore_score",
 ] as const;
 


### PR DESCRIPTION
### What
Removed duplicate "last_modified_t" entry from FACETS_SORT_OPTIONS in src/facets.ts.

### Why
The array contained duplicate values, which could lead to inconsistent behavior when sorting facets.

### Fixes
Fixes #793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate sort option from facet sorting selections to improve consistency and clarity in available sorting choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->