### PR TITLE
fix(search): guard against null body and missing hits field in search responses

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -51,6 +51,32 @@ export class SearchApi {
     });
   }
 
+  /**
+   * Normalizes a search result by ensuring `hits` is always an array.
+   *
+   * If the API returns a 200 response with a missing or non-array `hits`
+   * field (e.g. during a backend schema change or unexpected error format),
+   * this guard logs a warning and replaces `hits` with an empty array so
+   * callers never crash on `.hits.map(...)`.
+   *
+   * @param result - The raw result object from openapi-fetch.
+   * @returns The same result object, with `hits` guaranteed to be an array
+   *          if `data` is present.
+   */
+  private normalizeSearchResult<T extends { data?: unknown }>(result: T): T {
+    if (
+      result.data != null &&
+      !Array.isArray((result.data as { hits?: unknown }).hits)
+    ) {
+      console.warn(
+        "SearchApi: response missing 'hits' field — returning empty array as fallback",
+        result.data,
+      );
+      result.data = { ...(result.data as object), hits: [] } as typeof result.data;
+    }
+    return result;
+  }
+
   async getDocument(identifier: string, query?: DocumentQuery) {
     return this.client.GET("/document/{identifier}", {
       params: { path: { identifier }, query },
@@ -61,26 +87,12 @@ export class SearchApi {
     const result = await this.client.POST("/search", {
       body: body as unknown as RawSearchBody,
     });
-    if (result.data != null && result.data.hits == null) {
-      console.warn(
-        "SearchApi: response missing 'hits' field — returning empty array as fallback",
-        result.data,
-      );
-      result.data = { ...result.data, hits: [] };
-    }
-    return result;
+    return this.normalizeSearchResult(result);
   }
 
   async searchGet(query: SearchQuery) {
     const result = await this.client.GET("/search", { params: { query } });
-    if (result.data != null && result.data.hits == null) {
-      console.warn(
-        "SearchApi: response missing 'hits' field — returning empty array as fallback",
-        result.data,
-      );
-      result.data = { ...result.data, hits: [] };
-    }
-    return result;
+    return this.normalizeSearchResult(result);
   }
 
   async autocomplete(query: AutocompleteQuery) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -58,13 +58,29 @@ export class SearchApi {
   }
 
   async search(body: SearchBody) {
-    return this.client.POST("/search", {
+    const result = await this.client.POST("/search", {
       body: body as unknown as RawSearchBody,
     });
+    if (result.data != null && result.data.hits == null) {
+      console.warn(
+        "SearchApi: response missing 'hits' field — returning empty array as fallback",
+        result.data,
+      );
+      result.data = { ...result.data, hits: [] };
+    }
+    return result;
   }
 
   async searchGet(query: SearchQuery) {
-    return this.client.GET("/search", { params: { query } });
+    const result = await this.client.GET("/search", { params: { query } });
+    if (result.data != null && result.data.hits == null) {
+      console.warn(
+        "SearchApi: response missing 'hits' field — returning empty array as fallback",
+        result.data,
+      );
+      result.data = { ...result.data, hits: [] };
+    }
+    return result;
   }
 
   async autocomplete(query: AutocompleteQuery) {

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -240,5 +240,47 @@ describe("SearchApi Wrapper", () => {
       );
       consoleSpy.mockRestore();
     });
+
+    it("should return hits as empty array when hits is a non-array value in POST search", async () => {
+      // The Array.isArray guard also catches malformed values like {} or strings,
+      // not just null/undefined — this test documents that behaviour.
+      const consoleSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      fetchMock.mockResolvedValue(mockResponse({ count: 1, hits: {} }));
+
+      const result = await client.search({
+        q: "test",
+        langs: ["en"],
+        page_size: 20,
+        page: 1,
+      });
+
+      expect(result.data).toBeDefined();
+      expect(result.data!.hits).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("missing 'hits' field"),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should return hits as empty array when hits is a non-array value in GET search", async () => {
+      // Same Array.isArray guard applies to searchGet()
+      const consoleSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      fetchMock.mockResolvedValue(mockResponse({ count: 1, hits: {} }));
+
+      const result = await client.searchGet({ q: "test" });
+
+      expect(result.data).toBeDefined();
+      expect(result.data!.hits).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("missing 'hits' field"),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
   });
 });

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -184,9 +184,18 @@ describe("SearchApi Wrapper", () => {
   });
 
   describe("Malformed responses", () => {
-    it("should return null data when 200 response body is null", async () => {
-      // openapi-fetch treats 200 + null body as a successful response
-      // with data === null. The SDK should not crash in this case.
+    let consoleSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it("should return null data when POST search 200 response body is null", async () => {
+      // openapi-fetch treats 200 + null body as data === null; SDK must not crash.
       fetchMock.mockResolvedValue(mockResponse(null));
 
       const result = await client.search({
@@ -195,92 +204,50 @@ describe("SearchApi Wrapper", () => {
         page_size: 20,
         page: 1,
       });
-      // null body comes back as null data — callers must check before iterating
+
       expect(result.data).toBeNull();
       expect(result.response.status).toBe(200);
     });
 
-    it("should return hits as empty array when 200 response is missing hits field", async () => {
-      // Backend returns 200 but hits is undefined — guard should warn and fallback
-      const consoleSpy = jest
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
-      fetchMock.mockResolvedValue(mockResponse({ count: 0 }));
+    it.each([
+      ["hits field is missing", { count: 0 }],
+      ["hits is a non-array value", { count: 1, hits: {} }],
+    ])(
+      "should normalise hits to [] for POST search when %s",
+      async (_label, responseBody) => {
+        fetchMock.mockResolvedValue(mockResponse(responseBody));
 
-      const result = await client.search({
-        q: "test",
-        langs: ["en"],
-        page_size: 20,
-        page: 1,
-      });
+        const result = await client.search({
+          q: "test",
+          langs: ["en"],
+          page_size: 20,
+          page: 1,
+        });
 
-      expect(result.data).toBeDefined();
-      expect(result.data!.hits).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("missing 'hits' field"),
-        expect.anything(),
-      );
-      consoleSpy.mockRestore();
-    });
+        expect(result.data!.hits).toEqual([]);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining("missing 'hits' field"),
+          expect.anything(),
+        );
+      },
+    );
 
-    it("should return empty hits as fallback for GET search when hits field is missing", async () => {
-      // Same guard applies to searchGet()
-      const consoleSpy = jest
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
-      fetchMock.mockResolvedValue(mockResponse({ count: 0 }));
+    it.each([
+      ["hits field is missing", { count: 0 }],
+      ["hits is a non-array value", { count: 1, hits: {} }],
+    ])(
+      "should normalise hits to [] for GET search when %s",
+      async (_label, responseBody) => {
+        fetchMock.mockResolvedValue(mockResponse(responseBody));
 
-      const result = await client.searchGet({ q: "test" });
+        const result = await client.searchGet({ q: "test" });
 
-      expect(result.data).toBeDefined();
-      expect(result.data!.hits).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("missing 'hits' field"),
-        expect.anything(),
-      );
-      consoleSpy.mockRestore();
-    });
-
-    it("should return hits as empty array when hits is a non-array value in POST search", async () => {
-      // The Array.isArray guard also catches malformed values like {} or strings,
-      // not just null/undefined — this test documents that behaviour.
-      const consoleSpy = jest
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
-      fetchMock.mockResolvedValue(mockResponse({ count: 1, hits: {} }));
-
-      const result = await client.search({
-        q: "test",
-        langs: ["en"],
-        page_size: 20,
-        page: 1,
-      });
-
-      expect(result.data).toBeDefined();
-      expect(result.data!.hits).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("missing 'hits' field"),
-        expect.anything(),
-      );
-      consoleSpy.mockRestore();
-    });
-
-    it("should return hits as empty array when hits is a non-array value in GET search", async () => {
-      // Same Array.isArray guard applies to searchGet()
-      const consoleSpy = jest
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
-      fetchMock.mockResolvedValue(mockResponse({ count: 1, hits: {} }));
-
-      const result = await client.searchGet({ q: "test" });
-
-      expect(result.data).toBeDefined();
-      expect(result.data!.hits).toEqual([]);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("missing 'hits' field"),
-        expect.anything(),
-      );
-      consoleSpy.mockRestore();
-    });
+        expect(result.data!.hits).toEqual([]);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining("missing 'hits' field"),
+          expect.anything(),
+        );
+      },
+    );
   });
 });

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -182,4 +182,63 @@ describe("SearchApi Wrapper", () => {
       expect(result.response.status).toBe(503);
     });
   });
+
+  describe("Malformed responses", () => {
+    it("should return null data when 200 response body is null", async () => {
+      // openapi-fetch treats 200 + null body as a successful response
+      // with data === null. The SDK should not crash in this case.
+      fetchMock.mockResolvedValue(mockResponse(null));
+
+      const result = await client.search({
+        q: "test",
+        langs: ["en"],
+        page_size: 20,
+        page: 1,
+      });
+      // null body comes back as null data — callers must check before iterating
+      expect(result.data).toBeNull();
+      expect(result.response.status).toBe(200);
+    });
+
+    it("should return hits as empty array when 200 response is missing hits field", async () => {
+      // Backend returns 200 but hits is undefined — guard should warn and fallback
+      const consoleSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      fetchMock.mockResolvedValue(mockResponse({ count: 0 }));
+
+      const result = await client.search({
+        q: "test",
+        langs: ["en"],
+        page_size: 20,
+        page: 1,
+      });
+
+      expect(result.data).toBeDefined();
+      expect(result.data!.hits).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("missing 'hits' field"),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should return empty hits as fallback for GET search when hits field is missing", async () => {
+      // Same guard applies to searchGet()
+      const consoleSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      fetchMock.mockResolvedValue(mockResponse({ count: 0 }));
+
+      const result = await client.searchGet({ q: "test" });
+
+      expect(result.data).toBeDefined();
+      expect(result.data!.hits).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("missing 'hits' field"),
+        expect.anything(),
+      );
+      consoleSpy.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
## Description

`SearchApi.search()` and `SearchApi.searchGet()` use `openapi-fetch` which returns `{ data, error, response }` without validating the shape of the response body. If the search-a-licious backend returns HTTP 200 with a `null` body or with `hits` missing (e.g. during a backend deployment, schema change, or unexpected error format), any caller doing `result.data.hits.map(...)` crashes with a `TypeError`.

### Changes

**`src/search.ts`** — Added a defensive guard in `search()` and `searchGet()`:

```ts
if (result.data != null && result.data.hits == null) {
  console.warn(
    "SearchApi: response missing 'hits' field — returning empty array as fallback",
    result.data,
  );
  result.data = { ...result.data, hits: [] };
}
```

Design rationale (silent fallback + warn, not throw):
- ✅ UI never crashes — callers get `{ hits: [] }` instead
- ✅ Developers still see the anomaly via `console.warn` in DevTools
- ✅ Not a breaking change — return type `{ data, error, response }` is unchanged
- 📝 Maintainers can later upgrade to a stricter throw if preferred

**`tests/search.spec.ts`** — Added a new `describe("Malformed responses")` block with 3 test cases:

1. **200 + `null` body** — confirms `result.data` is null (no crash)
2. **200 + `{ hits: undefined }` body** — confirms guard fires, hits becomes `[]`, and `console.warn` is called
3. **200 + `{ hits: undefined }` via `searchGet()`** — same guard applied to the GET variant

## Related issue(s)

Fixes #825


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now normalizes malformed success responses so result lists are always arrays; when expected list data is missing or not an array, an empty list is returned and a diagnostic warning is emitted.

* **Tests**
  * New tests cover malformed success responses, verifying normalization, warning emission, and that HTTP success statuses are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->