### PR TITLE
fix: remove duplicate 'last_modified_t' from FACETS_SORT_OPTIONS

### DIFF
--- a/src/facets.ts
+++ b/src/facets.ts
@@ -5,7 +5,6 @@ export const FACETS_SORT_OPTIONS = [
   "popularity",
   "environmental_score_score",
   "created_t",
-  "last_modified_t",
   "nutriscore_score",
 ] as const;
 


### PR DESCRIPTION
### What
Improved all `@ts-expect-error` comments by adding clear and specific explanations.

### Why
The previous comments were vague or missing context. This change makes it easier to understand why type errors are intentionally suppressed, improving code readability and maintainability.

### Fixes
Fixes #799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unsupported sort option from facet sorting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->