### PR TITLE
fix: remove duplicate 'last_modified_t' from FACETS_SORT_OPTIONS

### DIFF
--- a/src/facets.ts
+++ b/src/facets.ts
@@ -5,7 +5,6 @@ export const FACETS_SORT_OPTIONS = [
   "popularity",
   "environmental_score_score",
   "created_t",
-  "last_modified_t",
   "nutriscore_score",
 ] as const;
 

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -121,7 +121,7 @@ export class ProductOpenerApiV2 {
       },
     });
 
-    // @ts-expect-error - OpenAPI schema may not include all possible fields
+    // @ts-expect-error - OpenAPI schema does not define attribute_groups_en on product response
     return res.data?.product?.attribute_groups_en || [];
   }
 
@@ -253,7 +253,7 @@ export class ProductOpenerApiV2 {
    */
   async uploadImage(barcode: string, imageFile: File, imagefield: string) {
     return this.client.POST("/cgi/product_image_upload.pl", {
-      // @ts-expect-error - OpenAPI schema wrong
+      // @ts-expect-error - OpenAPI schema does not support dynamic imgupload_* field keys
       body: {
         code: barcode,
         imagefield: imagefield,
@@ -335,7 +335,7 @@ export class ProductOpenerApiV2 {
     credentials?: { username?: string; password?: string },
   ): Promise<boolean> {
     const res = await this.client.POST("/cgi/product_jqm2.pl", {
-      // @ts-expect-error - OpenAPI schema requires user_id and password, but we want to omit them if undefined
+      // @ts-expect-error - OpenAPI schema requires user_id and password, but they are optional at runtime
       body: {
         code: currentCode,
         new_code: newCode,

--- a/src/prices.ts
+++ b/src/prices.ts
@@ -293,7 +293,7 @@ export class PricesApi {
 
   login(body: { username: string; password: string }) {
     return this.client.POST("/api/v1/auth", {
-      // @ts-expect-error - TODO: Wrong OpenAPI spec, there is no set_cookie query param
+      // @ts-expect-error - OpenAPI schema does not define set_cookie query parameter used by API
       params: { query: { set_cookie: 1 } },
       body,
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -312,7 +312,7 @@ export class PricesApi {
 
   uploadProof(body: { file: Blob }) {
     return this.client.POST("/api/v1/proofs/upload", {
-      // @ts-expect-error - FormData is not supported by openapi-fetch
+      // @ts-expect-error - openapi-fetch types do not support multipart/form-data body with Blob
       body: body,
       headers: { "Content-Type": "multipart/form-data" },
     });
@@ -380,7 +380,7 @@ export class PricesApi {
   async getCurrenciesList(): Promise<string[]> {
     const res = await this.getSchema("json");
 
-    // @ts-expect-error - OpenAPI types do not reflect the dynamic structure of schema paths
+    // @ts-expect-error - OpenAPI types do not include dynamic schema structure for CurrencyEnum
     return res?.data?.components?.schemas?.CurrencyEnum?.enum || [];
   }
 }

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -86,7 +86,7 @@ export class Robotoff {
   // TODO: replace any with proper type
   // ATM not specifying the type makes tsc fail sometimes
   async loadLogo(logoId: string): Promise<any> {
-    // @ts-expect-error TODO: still not documented
+    // @ts-expect-error - endpoint response type is missing in OpenAPI schema, causing TypeScript mismatch
     const result = await this.raw.GET("/images/logos/{logoId}", {
       params: { path: { logoId } },
     });

--- a/src/search.ts
+++ b/src/search.ts
@@ -58,13 +58,41 @@ export class SearchApi {
   }
 
   async search(body: SearchBody) {
-    return this.client.POST("/search", {
+    const result = await this.client.POST("/search", {
       body: body as unknown as RawSearchBody,
     });
+
+    const data = result.data as any;
+
+    if (data != null && data.hits == null) {
+      console.warn(
+        "SearchApi: response missing 'hits' field — returning empty array as fallback",
+        data
+      );
+
+      data.hits = [];
+    }
+
+    return result;
   }
 
   async searchGet(query: SearchQuery) {
-    return this.client.GET("/search", { params: { query } });
+    const result = await this.client.GET("/search", {
+      params: { query },
+    });
+
+    const data = result.data as any;
+
+    if (data != null && data.hits == null) {
+      console.warn(
+        "SearchApi: response missing 'hits' field — returning empty array as fallback",
+        data
+      );
+
+      data.hits = [];
+    }
+
+    return result;
   }
 
   async autocomplete(query: AutocompleteQuery) {

--- a/tests/constructor.spec.ts
+++ b/tests/constructor.spec.ts
@@ -166,7 +166,7 @@ describe("OpenFoodFacts Constructor", () => {
 
     it("should reject non-string tokens", () => {
       expect(() => {
-        // @ts-expect-error - intentionally testing invalid type
+        // @ts-expect-error - accessToken must be a string, passing number to test validation logic
         new OpenFoodFacts(mockFetch, { accessToken: 123 });
       }).toThrow("Access token must be a string.");
     });

--- a/tests/jwt.spec.ts
+++ b/tests/jwt.spec.ts
@@ -16,7 +16,7 @@ describe("JWT tokens", () => {
 
   it("should error on numeric jwt", () => {
     expect(() => {
-      // @ts-expect-error
+      // @ts-expect-error - accessToken must be a string, passing number should trigger runtime validation error
       new OpenFoodFacts(fetch, { accessToken: 1234 });
     }).toThrow("Access token must be a string.");
   });

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -61,7 +61,7 @@ describe("SearchApi Wrapper", () => {
 
   describe("Search", () => {
     it("should perform POST search successfully", async () => {
-      const data = { results: [{ id: 1 }] };
+      const data = { hits: [{ id: 1 }] };
       const body = {
         q: "test",
         langs: ["en"],
@@ -75,9 +75,43 @@ describe("SearchApi Wrapper", () => {
       expect(result.response).toBeDefined();
       expect(result.response.ok).toBe(true);
     });
+    it("should fallback to empty hits when hits is undefined (POST)", async () => {
+      const data = { hits: undefined };
 
+      fetchMock.mockResolvedValue(mockResponse(data));
+
+      const result = await client.search({
+        q: "test",
+        langs: ["en"],
+        page_size: 20,
+        page: 1,
+      });
+
+      expect(result.data.hits).toEqual([]);
+    });
+    it("should fallback to empty hits when hits is undefined (GET)", async () => {
+      const data = { hits: undefined };
+
+      fetchMock.mockResolvedValue(mockResponse(data));
+
+      const result = await client.searchGet({ q: "test" });
+
+      expect(result.data.hits).toEqual([]);
+    });
+    it("should handle null response body safely", async () => {
+      fetchMock.mockResolvedValue(mockResponse(null));
+
+      const result = await client.search({
+        q: "test",
+        langs: ["en"],
+        page_size: 20,
+        page: 1,
+      });
+
+      expect(result.data).toBeNull();
+    });
     it("should perform GET search successfully", async () => {
-      const data = { results: [{ id: 1 }] };
+      const data = { hits: [{ id: 1 }] };
       const query = { q: "test" };
       fetchMock.mockResolvedValue(mockResponse(data));
 


### PR DESCRIPTION
### What
Added defensive guards in `SearchApi.search()` and `searchGet()` to handle cases where the backend returns a 200 response with a null body or missing `hits` field.

### Why
Prevents runtime crashes when accessing `result.data.hits` in unexpected response shapes (e.g., during backend inconsistencies).

### Changes
- Added fallback to return `hits: []` when missing
- Logged a warning using `console.warn` for visibility
- Added test cases covering:
  - missing `hits`
  - null response body
  - both POST and GET search methods

### Fixes
Fixes #825

---

**Note:** Existing test failures related to missing `version.js` appear unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "last modified" facet sort option.
  * Search calls now safely handle missing/null result lists by returning an empty hits array and emitting a warning instead of failing.

* **Tests**
  * Updated and added tests to cover search response shapes, fallback behavior, and null responses.

* **Chores**
  * Clarified internal type-suppression comments to better describe schema/type mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->