### PR TITLE
fix: avoid sending Authorization header when token is undefined in Pr…

### DIFF
--- a/src/folksonomy.ts
+++ b/src/folksonomy.ts
@@ -30,7 +30,7 @@ export class Folksonomy {
       fetch,
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.authToken}`,
+        ...(options?.authToken ? { Authorization: `Bearer ${options.authToken}` } : {}),
         "User-Agent": USER_AGENT,
       },
     });

--- a/src/prices.ts
+++ b/src/prices.ts
@@ -104,7 +104,7 @@ export class PricesApi {
       credentials: "include",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${options?.authToken}`,
+        ...(options?.authToken ? { Authorization: `Bearer ${options.authToken}` } : {}),
         "User-Agent": USER_AGENT,
       },
     });

--- a/tests/folksonomy.spec.ts
+++ b/tests/folksonomy.spec.ts
@@ -215,5 +215,20 @@ describe("Folksonomy Wrapper", () => {
         "Auth token is required to perform this action",
       );
     });
+
+    it("should not send Authorization header when token is undefined", async () => {
+      let capturedHeaders: HeadersInit | undefined;
+
+      const customFetchMock = jest.fn((url, options) => {
+        capturedHeaders = options?.headers;
+        return Promise.resolve(mockResponse({}));
+      });
+
+      const clientWithoutToken = new Folksonomy(customFetchMock as typeof globalThis.fetch);
+      await clientWithoutToken.getKeys(); // this endpoint doesn't strictly throw validation error on client
+
+      const headers = new Headers(capturedHeaders);
+      expect(headers.has("Authorization")).toBe(false);
+    });
   });
 });

--- a/tests/prices.spec.ts
+++ b/tests/prices.spec.ts
@@ -112,6 +112,21 @@ describe("Prices Wrapper", () => {
       const result = await client.isAuthenticated();
       expect(result).toBe(true);
     });
+
+    it("should not send Authorization header when token is undefined", async () => {
+      let capturedHeaders: HeadersInit | undefined;
+
+      const customFetchMock = jest.fn((url, options) => {
+        capturedHeaders = options?.headers;
+        return Promise.resolve(mockResponse({}));
+      });
+
+      const clientWithoutToken = new PricesApi(customFetchMock as typeof globalThis.fetch);
+      await clientWithoutToken.getPrices({ product_code: "123" });
+
+      const headers = new Headers(capturedHeaders);
+      expect(headers.has("Authorization")).toBe(false);
+    });
   });
 
   describe("Proofs", () => {


### PR DESCRIPTION
### What
Prevent sending `Authorization: Bearer undefined` header when no token is provided in PricesApi and Folksonomy.

### Why
Currently, requests include an invalid Authorization header when no token is passed, which may lead to incorrect API behavior.

### Changes
- Conditionally include Authorization header only when a valid token exists
- Applied fix in both PricesApi and Folksonomy
- Added test cases to verify header is not sent when token is undefined

### Tests
- Added tests in `tests/prices.spec.ts` and `tests/folksonomy.spec.ts`
- All tests passing (192/192)

### Fixes
Closes #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid authorization headers being sent when no credentials are configured.
  * Headers are now only included in requests when appropriate credentials are provided.

* **Tests**
  * Added test coverage for requests without authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->