### PR TITLE
chore: update the readme code sample to use the correct getProductV3 method from OpenFoodFacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const client = new OpenFoodFacts(fetch);
 
 (async () => {
   // then you can use the client to access the Open Food Facts API
-  const { data, error } = await client.getProduct("5000112546415");
+  const { data, error } = await client.getProductV3("5000112546415");
   if (!data) {
     console.error("Error fetching product:", error);
     return;


### PR DESCRIPTION
### What
Currently the code sample inside the README file uses getProduct on OpenFoodFacts, but that method does not exist inside OpenFoodFacts class.
I think the method has be updated to getProductV2 and getProductV3.

This PR update the README file to use the latest method which is getProductV3 


### Fixes bug #839



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README example code to reflect current recommended SDK usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->