### PR TITLE
fix(auth): handle false token expiration dates and ensure boolean return

### DIFF
--- a/src/off.ts
+++ b/src/off.ts
@@ -305,17 +305,20 @@ export class OpenFoodFacts {
     return newAccessToken;
   }
 
-  private isTokenExpired(token: string) {
+  private isTokenExpired(token: string) : boolean {
     const parts = token.split(".");
     if (parts.length !== 3) {
       throw new Error("Invalid JWT token format");
     }
     const payload = JSON.parse(
       Buffer.from(parts[1], "base64").toString("utf-8"),
-    ) as { exp: number };
+    ) as { exp?: number };
 
+    if (payload.exp == null) {
+      return false; 
+    }
     // Check if the token is expired
-    return payload.exp && Date.now() >= payload.exp * 1000;
+    return Date.now() >= payload.exp * 1000;
   }
 
   ////////////////

--- a/src/off.ts
+++ b/src/off.ts
@@ -305,7 +305,7 @@ export class OpenFoodFacts {
     return newAccessToken;
   }
 
-  private isTokenExpired(token: string) : boolean {
+  private isTokenExpired(token: string): boolean {
     const parts = token.split(".");
     if (parts.length !== 3) {
       throw new Error("Invalid JWT token format");
@@ -314,11 +314,8 @@ export class OpenFoodFacts {
       Buffer.from(parts[1], "base64").toString("utf-8"),
     ) as { exp?: number };
 
-    if (payload.exp == null) {
-      return false; 
-    }
     // Check if the token is expired
-    return Date.now() >= payload.exp * 1000;
+    return payload.exp != null && Date.now() >= payload.exp * 1000;
   }
 
   ////////////////

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -562,6 +562,25 @@ describe("OpenFoodFacts", () => {
     });
   });
 
+  describe("isTokenExpired edge cases", () => {
+    const createDummyToken = (payloadObj: any) => {
+      const payloadBase64 = Buffer.from(JSON.stringify(payloadObj)).toString('base64');
+      return `dummyHeader.${payloadBase64}.dummySignature`;
+    };
+
+    it("should treat a token with exp = 0 as expired", () => {
+      const token = createDummyToken({ exp: 0 });
+      const isExpired = (productsApi as any).isTokenExpired(token);
+      expect(isExpired).toBe(true);
+    });
+
+    it("should return false (not expired) if exp claim is missing/undefined", () => {
+      const token = createDummyToken({ userId: 123 }); 
+      const isExpired = (productsApi as any).isTokenExpired(token);
+      expect(isExpired).toBe(false); 
+    });
+  });
+
   describe("error handling and edge cases", () => {
     const testCases = [
       { description: "empty barcode", barcode: "", expected: null },

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -564,7 +564,9 @@ describe("OpenFoodFacts", () => {
 
   describe("isTokenExpired edge cases", () => {
     const createDummyToken = (payloadObj: any) => {
-      const payloadBase64 = Buffer.from(JSON.stringify(payloadObj)).toString('base64');
+      const payloadBase64 = Buffer.from(JSON.stringify(payloadObj)).toString(
+        "base64",
+      );
       return `dummyHeader.${payloadBase64}.dummySignature`;
     };
 
@@ -575,9 +577,9 @@ describe("OpenFoodFacts", () => {
     });
 
     it("should return false (not expired) if exp claim is missing/undefined", () => {
-      const token = createDummyToken({ userId: 123 }); 
+      const token = createDummyToken({ userId: 123 });
       const isExpired = (productsApi as any).isTokenExpired(token);
-      expect(isExpired).toBe(false); 
+      expect(isExpired).toBe(false);
     });
   });
 


### PR DESCRIPTION
### What
This PR rewrites the JWT expiration logic in `OpenFoodFacts.isTokenExpired()` (`off.ts`). It checks for `null` or `undefined` directly instead of relying on truthiness.

Previously, `payload.exp && Date.now() >= payload.exp * 1000` had two edge cases:
1. **The `exp = 0` Issue:** Tokens revoked by the backend with an `exp` of `0` were treated as falsy. This bypassed the timestamp check and returned `0`.
2. **Type Safety:** Tokens lacking an `exp` claim returned `undefined`, which is not a strict `boolean`.

This update ensures a strict `: boolean` return type and treats `exp = 0` as an expired token.

**Testing Added:** I have also added dedicated test cases in `tests/off.spec.ts` to ensure that `exp = 0` and missing `exp` claims are evaluated correctly, preventing future regressions.

### Screenshot
N/A - Internal logic and type-safety fix.

### Fixes bug(s)
- Fixes #841 

### Part of 
- N/A (Standalone tech-debt cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token expiration handling so tokens missing an expiry are treated as valid and truly expired tokens are correctly recognized, reducing unexpected sign-outs and improving authentication stability.

* **Tests**
  * Added tests covering edge cases around token expiry claims to prevent regressions and ensure consistent authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->