### PR TITLE
feat(nutripatrol): add barcode filter to getTickets and fix type parameter

### DIFF
--- a/src/nutripatrol.ts
+++ b/src/nutripatrol.ts
@@ -94,7 +94,7 @@ export class NutriPatrol {
    * const { data, error } = await nutripatrol.getTickets({
    *   barcode: "3017620422003",
    *   status: "open",
-   *   type_: "product",
+   *   type: "product",
    *   reason: ["inappropriate", "human"],
    *   page: 1,
    *   page_size: 20,
@@ -103,12 +103,20 @@ export class NutriPatrol {
   getTickets(query: {
     barcode?: string;
     status?: components["schemas"]["TicketStatus"];
-    type_?: components["schemas"]["IssueType"];
+    type?: components["schemas"]["IssueType"];
     reason?: components["schemas"]["ReasonType"][];
     page?: number;
     page_size?: number;
   }) {
-    return this.client.GET("/api/v1/tickets", { params: { query } });
+    const { type, ...rest } = query;
+    return this.client.GET("/api/v1/tickets", {
+      params: {
+        query: {
+          ...rest,
+          type_: type,
+        },
+      },
+    });
   }
 
   /**

--- a/src/nutripatrol.ts
+++ b/src/nutripatrol.ts
@@ -9,6 +9,8 @@ export type Flag = components["schemas"]["Flag"];
 export type Ticket = components["schemas"]["Ticket"];
 export type TicketStatus = components["schemas"]["TicketStatus"];
 export type StatsResponse = components["schemas"]["StatsResponse"];
+export type IssueType = components["schemas"]["IssueType"];
+export type ReasonType = components["schemas"]["ReasonType"];
 
 export class NutriPatrol {
   private readonly fetch: typeof global.fetch;
@@ -90,17 +92,19 @@ export class NutriPatrol {
    * @returns A promise that resolves with the list of tickets or error.
    * @example
    * const { data, error } = await nutripatrol.getTickets({
+   *   barcode: "3017620422003",
    *   status: "open",
-   *   type: "spam",
+   *   type_: "product",
    *   reason: ["inappropriate", "human"],
    *   page: 1,
    *   page_size: 20,
    * });
    */
   getTickets(query: {
-    status: "open" | "closed";
-    type?: string;
-    reason?: ("inappropriate" | "human" | "beauty" | "other")[];
+    barcode?: string;
+    status?: components["schemas"]["TicketStatus"];
+    type_?: components["schemas"]["IssueType"];
+    reason?: components["schemas"]["ReasonType"][];
     page?: number;
     page_size?: number;
   }) {

--- a/src/schemas/nutripatrol.ts
+++ b/src/schemas/nutripatrol.ts
@@ -640,6 +640,7 @@ export interface operations {
     get_tickets_api_v1_tickets_get: {
         parameters: {
             query?: {
+                barcode?: string | null;
                 status?: components["schemas"]["TicketStatus"] | null;
                 type_?: components["schemas"]["IssueType"] | null;
                 reason?: components["schemas"]["ReasonType"][] | null;

--- a/src/schemas/nutripatrol.ts
+++ b/src/schemas/nutripatrol.ts
@@ -257,6 +257,8 @@ export interface components {
             /**
              * Image Id
              * @description ID of the flagged image
+             * @example 1
+             * @example front_fr
              */
             image_id?: string | null;
             /** @description Flavor (project) associated with the ticket */
@@ -322,6 +324,8 @@ export interface components {
             /**
              * Image Id
              * @description ID of the flagged image
+             * @example 1
+             * @example front_fr
              */
             image_id?: string | null;
             /** @description Flavor (project) associated with the ticket */
@@ -474,6 +478,8 @@ export interface components {
             /**
              * Image Id
              * @description ID of the flagged image, if the ticket type is `image`
+             * @example 1
+             * @example front_fr
              */
             image_id?: string | null;
             /** @description Flavor (project) associated with the ticket */

--- a/tests/nutripatrol.spec.ts
+++ b/tests/nutripatrol.spec.ts
@@ -165,6 +165,26 @@ describe("NutriPatrol Wrapper", () => {
       expect(data).toEqual(mockData);
     });
 
+    it("should fetch tickets filtered by barcode", async () => {
+      const mockData = {
+        tickets: [{ id: 1, status: "open", barcode: "3017620422003" }],
+        max_page: 1,
+      };
+      fetchMock.mockResolvedValue(mockResponse(mockData));
+
+      const { data, error } = await client.getTickets({
+        barcode: "3017620422003",
+        status: "open",
+      });
+
+      expect(error).toBeUndefined();
+      expect(data).toEqual(mockData);
+      // Verify the barcode was passed in the URL
+      const fetchArg = fetchMock.mock.calls[0][0];
+      const url = typeof fetchArg === "string" ? fetchArg : fetchArg.url;
+      expect(url).toContain("barcode=3017620422003");
+    });
+
     it("should handle error when fetching tickets", async () => {
       fetchMock.mockResolvedValue(mockResponse(null, false, 404));
 


### PR DESCRIPTION
### What
- Add barcode filtering to getTickets (https://github.com/openfoodfacts/nutripatrol/pull/153)
- Replaced type with type_ as the backend(nutripatrol) expects

### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/639


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional barcode filtering to ticket queries and made all ticket query parameters optional.
  * Replaced prior issue/type/reason typings with OpenAPI-backed issue and reason types; query parameter mapping now sends type as type_.

* **Documentation**
  * Added example metadata for image identifiers in relevant schemas.

* **Tests**
  * Added a test verifying ticket filtering includes barcode in requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->