### PR TITLE
fix(types): correct return type for getPackagings method

### DIFF
--- a/src/off.ts
+++ b/src/off.ts
@@ -19,6 +19,7 @@ import type {
   Label,
   Language,
   Nutrient,
+  Packaging,
   State,
   Store,
   TaxoNode,
@@ -361,8 +362,8 @@ export class OpenFoodFacts {
     return this.getTaxo<Ingredient>("ingredients");
   }
 
-  getPackagings(): Promise<Taxonomy<Ingredient>> {
-    return this.getTaxo<Ingredient>("packaging");
+  getPackagings(): Promise<Taxonomy<Packaging>> {
+    return this.getTaxo<Packaging>("packaging");
   }
 
   getStates(): Promise<Taxonomy<State>> {

--- a/src/taxonomy/types.ts
+++ b/src/taxonomy/types.ts
@@ -25,6 +25,8 @@ export type Label = TaxoNode & {
 
 export type Ingredient = TaxoNode & object;
 
+export type Packaging = TaxoNode & {};
+
 export type State = TaxoNode & {};
 
 export type Category = TaxoNode & {

--- a/src/taxonomy/types.ts
+++ b/src/taxonomy/types.ts
@@ -25,7 +25,7 @@ export type Label = TaxoNode & {
 
 export type Ingredient = TaxoNode & object;
 
-export type Packaging = TaxoNode & {};
+export type Packaging = TaxoNode & object;
 
 export type State = TaxoNode & {};
 


### PR DESCRIPTION
### What  
Fixed a typo in the `getPackagings()` method. It was returning a `Taxonomy<Ingredient>` instead of the correct packaging taxonomy.  

Changes:  
1. Created a new `Packaging` type that extends `TaxoNode` in the type definitions.  
2. Updated `getPackagings()` to use the new `Packaging` type instead of `Ingredient`.  

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->
- N/A (Code Improvement)

### Fixes bug(s)  
- N/A (Typing fix)  

### Part of  
- General TypeScript strictness and type safety improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for packaging taxonomy so packaging entries are properly recognized and surfaced.

* **Bug Fixes**
  * Fixed packaging data retrieval to return the correct packaging taxonomy, improving accuracy and consistency of displayed packaging information across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->