### PR TITLE
Bump version to 2.0.0-alpha.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@openfoodfacts/openfoodfacts-nodejs",
   "author": "openfoodfacts",
   "license": "Apache-2.0",
-  "version": "2.0.0-alpha.29",
+  "version": "2.0.0-alpha.30",
   "description": "Open Food Facts API NodeJS Wrapper",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
I noticed you trigger a run for the alpha.30 releasE. But I assume it will not work if you don't bump the package version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.0.0-alpha.30

<!-- end of auto-generated comment: release notes by coderabbit.ai -->