### PR TITLE
fix: /api/v1 will be added if its not sent in robotoff

### DIFF
--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -40,7 +40,7 @@ export class Robotoff {
     options: { baseUrl: string } = { baseUrl: DEFAULT_ROBOTOFF_API_URL },
   ) {
     this.fetch = fetch;
-    const baseUrl = options.baseUrl.endsWith("/api/v1") ? options.baseUrl : options.baseUrl + "/api/v1";
+    const baseUrl = new URL("/api/v1", options.baseUrl).toString();
     this.raw = createClient<paths>({
       fetch: this.fetch,
       baseUrl: baseUrl,

--- a/src/robotoff.ts
+++ b/src/robotoff.ts
@@ -40,9 +40,10 @@ export class Robotoff {
     options: { baseUrl: string } = { baseUrl: DEFAULT_ROBOTOFF_API_URL },
   ) {
     this.fetch = fetch;
+    const baseUrl = options.baseUrl.endsWith("/api/v1") ? options.baseUrl : options.baseUrl + "/api/v1";
     this.raw = createClient<paths>({
       fetch: this.fetch,
-      baseUrl: options.baseUrl,
+      baseUrl: baseUrl,
       headers: {
         "User-Agent": USER_AGENT,
       },


### PR DESCRIPTION
### What
Checking for api/v1 and added if not sent.
I'm not quite sure if this is the correct fix? Correct me if I'm wrong.
### Part of 
- https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized and standardized the API base URL used by the client by resolving the API version path against the configured base URL, ensuring all requests target the intended API version consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->