### PR TITLE
fix: include src files in tsconfig for TypeDoc

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -14,5 +14,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "verbatimModuleSyntax": true
-  }
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
### What
Add `src/**/*.ts` to the `include` section of `tsconfig.esm.json`.

### Why
TypeDoc failed during `yarn build:docs` because `src/index.ts` was not included in the active TypeScript configuration.

### Changes
- Added `"include": ["src/**/*.ts"]` to `tsconfig.esm.json`

### Expected Result
The Build Docs workflow can now locate `src/index.ts` and generate documentation successfully.

### Fixes
Fixes #864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript configuration file formatting to ensure proper structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-js/pull/865)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->