### PR TITLE
fix: pass no nutrition data information field

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -169,8 +169,7 @@ export class ProductOpenerApiV2 {
       labels: product.labels || "",
       brands: product.brands || "",
       quantity: product.quantity || "",
-      serving_size:
-        product.no_nutrition_data === true ? "" : product.serving_size || "",
+      serving_size: product.serving_size || "",
       stores: product.stores || "",
       origins: product.origins || "",
       countries: product.countries || "",

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -169,7 +169,8 @@ export class ProductOpenerApiV2 {
       labels: product.labels || "",
       brands: product.brands || "",
       quantity: product.quantity || "",
-      serving_size: product.serving_size || "",
+      serving_size:
+        product.no_nutrition_data === true ? "" : product.serving_size || "",
       stores: product.stores || "",
       origins: product.origins || "",
       countries: product.countries || "",
@@ -179,6 +180,7 @@ export class ProductOpenerApiV2 {
       comment: product.comment ?? "",
       product_name: product.product_name || "",
       ingredients_text: product.ingredients_text || "",
+      no_nutrition_data: product.no_nutrition_data === true ? "on" : "",
       ...productNames,
       ...ingredientsTexts,
     });


### PR DESCRIPTION
### What
Updated `addOrEditProductV2` method to correctly pass the `no_nutrition_data` toggle state to the server, enabling it to automatically handle wiping nutrient data (when the No nutrition info toggle is enabled). When the server receives `no_nutrition_data: "on"`, it safely ignores all submitted nutrient fields. Additionally, as the server treats `serving_size` as a generic text field rather than a nutrient, it now ensures that `serving_size` explicitly send as an empty string when the toggle is active to guarantee a completely clean database entry.

### Screenshot
<img width="1207" height="731" alt="Screenshot 2026-05-17 084517" src="https://github.com/user-attachments/assets/1ef2b5af-9435-417a-bc42-47f264e09307" />


### Fixes bug(s)
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1345



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Products flagged as having no nutrition data are now correctly included when submitting the product form.
  * This ensures such products save reliably and prevents loss of the "no nutrition data" selection during create/edit operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfoodfacts/openfoodfacts-js/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->