### PR TITLE
feat: support editing nutrition information

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -5,6 +5,7 @@ import { formData } from "./openapi.js";
 import { USER_AGENT } from "./consts.js";
 import type { ProductDataType } from "./off-v3.js";
 import type { FetchFn } from "./index.js";
+import { buildNutritionParams } from "./utils.js";
 
 export type SearchQuery = operations["get-search"]["parameters"]["query"];
 export type AttributeGroups = components["schemas"]["get_attribute_groups"];
@@ -129,84 +130,6 @@ export class ProductOpenerApiV2 {
   }
 
   /**
-   * Maps nested product nutriments to flat CGI query parameters expected by the server.
-   *
-   * Maps suffixes (_100g, _serving, _unit, _modifier) to their flat CGI representations
-   * (e.g. nutriment_[nid], nutriment_[nid]_unit, nutriment_[nid]_modifier).
-   *
-   * @param nutriments - The nutriments object from the product
-   * @returns A record of flat CGI parameters ready for form submission
-   */
-  private isPrimitiveValue(value: unknown): value is string | number | boolean {
-    if (value === undefined || value === null) {
-      return false;
-    }
-    const valType = typeof value;
-    return (
-      valType === "string" || valType === "number" || valType === "boolean"
-    );
-  }
-
-  private getNutritionDataPer(
-    nutriments: Record<string, unknown>,
-  ): NutritionDataPer | undefined {
-    let nutritionDataPer: NutritionDataPer | undefined;
-    for (const [key, value] of Object.entries(nutriments)) {
-      if (!this.isPrimitiveValue(value)) continue;
-
-      if (key.endsWith("_100g")) {
-        return "100g";
-      }
-      if (key.endsWith("_serving")) {
-        nutritionDataPer = "serving";
-      }
-    }
-    return nutritionDataPer;
-  }
-
-  private processNutrimentEntry(
-    key: string,
-    value: string | number | boolean,
-    nutritionDataPer: NutritionDataPer | undefined,
-    params: Record<string, string>,
-  ): void {
-    const strVal = String(value);
-
-    if (key.endsWith("_100g") && nutritionDataPer === "100g") {
-      const nid = key.slice(0, -5);
-      params[`nutriment_${nid}`] = strVal;
-    } else if (key.endsWith("_serving") && nutritionDataPer === "serving") {
-      const nid = key.slice(0, -8);
-      params[`nutriment_${nid}`] = strVal;
-    } else if (key.endsWith("_unit")) {
-      const nid = key.slice(0, -5);
-      params[`nutriment_${nid}_unit`] = strVal;
-    } else if (key.endsWith("_modifier")) {
-      const nid = key.slice(0, -9);
-      params[`nutriment_${nid}_modifier`] = strVal;
-    }
-  }
-
-  private buildNutritionParams(
-    nutriments: Record<string, unknown>,
-  ): Record<string, string> {
-    const params: Record<string, string> = {};
-
-    const nutritionDataPer = this.getNutritionDataPer(nutriments);
-    if (nutritionDataPer) {
-      params["nutrition_data_per"] = nutritionDataPer;
-    }
-
-    for (const [key, value] of Object.entries(nutriments)) {
-      if (this.isPrimitiveValue(value)) {
-        this.processNutrimentEntry(key, value, nutritionDataPer, params);
-      }
-    }
-
-    return params;
-  }
-
-  /**
    * Adds or edits a product using the V2 API
    * @param product - The product data to add or edit
    * @param credentials - Optional credentials for authentication
@@ -247,7 +170,7 @@ export class ProductOpenerApiV2 {
     // When unchecked, translate the nutriments object into flat CGI parameters.
     const nutritionParams =
       !noNutrition && product.nutriments
-        ? this.buildNutritionParams(product.nutriments)
+        ? buildNutritionParams(product.nutriments)
         : {};
 
     const body = formData({

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -22,6 +22,8 @@ export type ProductAttributeGroup = {
   attributes: ProductAttribute[];
 };
 
+export type NutritionDataPer = "100g" | "serving";
+
 /**
  * The OpenFoodFacts main API client for version 2.
  *
@@ -147,8 +149,8 @@ export class ProductOpenerApiV2 {
 
   private getNutritionDataPer(
     nutriments: Record<string, unknown>,
-  ): "100g" | "serving" | undefined {
-    let nutritionDataPer: "100g" | "serving" | undefined;
+  ): NutritionDataPer | undefined {
+    let nutritionDataPer: NutritionDataPer | undefined;
     for (const [key, value] of Object.entries(nutriments)) {
       if (!this.isPrimitiveValue(value)) continue;
 
@@ -165,7 +167,7 @@ export class ProductOpenerApiV2 {
   private processNutrimentEntry(
     key: string,
     value: string | number | boolean,
-    nutritionDataPer: "100g" | "serving" | undefined,
+    nutritionDataPer: NutritionDataPer | undefined,
     params: Record<string, string>,
   ): void {
     const strVal = String(value);

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -127,6 +127,46 @@ export class ProductOpenerApiV2 {
   }
 
   /**
+   * Maps nested product nutriments to flat CGI query parameters expected by the server.
+   *
+   * Maps suffixes (_100g, _serving, _unit, _modifier) to their flat CGI representations
+   * (e.g. nutriment_[nid], nutriment_[nid]_unit, nutriment_[nid]_modifier).
+   *
+   * @param nutriments - The nutriments object from the product
+   * @returns A record of flat CGI parameters ready for form submission
+   */
+  private buildNutritionParams(
+    nutriments: Record<string, unknown>,
+  ): Record<string, string> {
+    const params: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(nutriments)) {
+      if (value === undefined || value === null) continue;
+
+      const strVal = String(value);
+
+      if (key.endsWith("_100g")) {
+        const nid = key.slice(0, -"_100g".length);
+        params[`nutriment_${nid}`] = strVal;
+        // Only set nutrition_data_per if not already determined
+        params["nutrition_data_per"] ??= "100g";
+      } else if (key.endsWith("_serving")) {
+        const nid = key.slice(0, -"_serving".length);
+        params[`nutriment_${nid}`] = strVal;
+        params["nutrition_data_per"] ??= "serving";
+      } else if (key.endsWith("_unit")) {
+        const nid = key.slice(0, -"_unit".length);
+        params[`nutriment_${nid}_unit`] = strVal;
+      } else if (key.endsWith("_modifier")) {
+        const nid = key.slice(0, -"_modifier".length);
+        params[`nutriment_${nid}_modifier`] = strVal;
+      }
+    }
+
+    return params;
+  }
+
+  /**
    * Adds or edits a product using the V2 API
    * @param product - The product data to add or edit
    * @param credentials - Optional credentials for authentication
@@ -161,6 +201,15 @@ export class ProductOpenerApiV2 {
       {} as Record<string, string>,
     );
 
+    const noNutrition = product.no_nutrition_data === true;
+
+    // When no_nutrition_data is checked, the server handles clearing nutriments.
+    // When unchecked, translate the nutriments object into flat CGI parameters.
+    const nutritionParams =
+      !noNutrition && product.nutriments
+        ? this.buildNutritionParams(product.nutriments)
+        : {};
+
     const body = formData({
       code: product.code,
       user_id: credentials?.username,
@@ -179,9 +228,10 @@ export class ProductOpenerApiV2 {
       comment: product.comment ?? "",
       product_name: product.product_name || "",
       ingredients_text: product.ingredients_text || "",
-      no_nutrition_data: product.no_nutrition_data === true ? "on" : "",
+      no_nutrition_data: noNutrition ? "on" : "",
       ...productNames,
       ...ingredientsTexts,
+      ...nutritionParams,
     });
 
     const res = await this.fetch(url, {

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -140,20 +140,43 @@ export class ProductOpenerApiV2 {
   ): Record<string, string> {
     const params: Record<string, string> = {};
 
+    let nutritionDataPer: "100g" | "serving" | undefined;
+    for (const key of Object.keys(nutriments)) {
+      if (key.endsWith("_100g")) {
+        nutritionDataPer = "100g";
+        break;
+      } else if (key.endsWith("_serving")) {
+        nutritionDataPer = "serving";
+      }
+    }
+
+    if (nutritionDataPer) {
+      params["nutrition_data_per"] = nutritionDataPer;
+    }
+
     for (const [key, value] of Object.entries(nutriments)) {
       if (value === undefined || value === null) continue;
+
+      // Skip non-primitive types (objects, arrays, functions)
+      const valType = typeof value;
+      if (
+        valType !== "string" &&
+        valType !== "number" &&
+        valType !== "boolean"
+      ) {
+        continue;
+      }
 
       const strVal = String(value);
 
       if (key.endsWith("_100g")) {
+        if (nutritionDataPer !== "100g") continue;
         const nid = key.slice(0, -"_100g".length);
         params[`nutriment_${nid}`] = strVal;
-        // Only set nutrition_data_per if not already determined
-        params["nutrition_data_per"] ??= "100g";
       } else if (key.endsWith("_serving")) {
+        if (nutritionDataPer !== "serving") continue;
         const nid = key.slice(0, -"_serving".length);
         params[`nutriment_${nid}`] = strVal;
-        params["nutrition_data_per"] ??= "serving";
       } else if (key.endsWith("_unit")) {
         const nid = key.slice(0, -"_unit".length);
         params[`nutriment_${nid}_unit`] = strVal;

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -135,54 +135,69 @@ export class ProductOpenerApiV2 {
    * @param nutriments - The nutriments object from the product
    * @returns A record of flat CGI parameters ready for form submission
    */
+  private isPrimitiveValue(value: unknown): value is string | number | boolean {
+    if (value === undefined || value === null) {
+      return false;
+    }
+    const valType = typeof value;
+    return (
+      valType === "string" || valType === "number" || valType === "boolean"
+    );
+  }
+
+  private getNutritionDataPer(
+    nutriments: Record<string, unknown>,
+  ): "100g" | "serving" | undefined {
+    let nutritionDataPer: "100g" | "serving" | undefined;
+    for (const [key, value] of Object.entries(nutriments)) {
+      if (!this.isPrimitiveValue(value)) continue;
+
+      if (key.endsWith("_100g")) {
+        return "100g";
+      }
+      if (key.endsWith("_serving")) {
+        nutritionDataPer = "serving";
+      }
+    }
+    return nutritionDataPer;
+  }
+
+  private processNutrimentEntry(
+    key: string,
+    value: string | number | boolean,
+    nutritionDataPer: "100g" | "serving" | undefined,
+    params: Record<string, string>,
+  ): void {
+    const strVal = String(value);
+
+    if (key.endsWith("_100g") && nutritionDataPer === "100g") {
+      const nid = key.slice(0, -5);
+      params[`nutriment_${nid}`] = strVal;
+    } else if (key.endsWith("_serving") && nutritionDataPer === "serving") {
+      const nid = key.slice(0, -8);
+      params[`nutriment_${nid}`] = strVal;
+    } else if (key.endsWith("_unit")) {
+      const nid = key.slice(0, -5);
+      params[`nutriment_${nid}_unit`] = strVal;
+    } else if (key.endsWith("_modifier")) {
+      const nid = key.slice(0, -9);
+      params[`nutriment_${nid}_modifier`] = strVal;
+    }
+  }
+
   private buildNutritionParams(
     nutriments: Record<string, unknown>,
   ): Record<string, string> {
     const params: Record<string, string> = {};
 
-    let nutritionDataPer: "100g" | "serving" | undefined;
-    for (const key of Object.keys(nutriments)) {
-      if (key.endsWith("_100g")) {
-        nutritionDataPer = "100g";
-        break;
-      } else if (key.endsWith("_serving")) {
-        nutritionDataPer = "serving";
-      }
-    }
-
+    const nutritionDataPer = this.getNutritionDataPer(nutriments);
     if (nutritionDataPer) {
       params["nutrition_data_per"] = nutritionDataPer;
     }
 
     for (const [key, value] of Object.entries(nutriments)) {
-      if (value === undefined || value === null) continue;
-
-      // Skip non-primitive types (objects, arrays, functions)
-      const valType = typeof value;
-      if (
-        valType !== "string" &&
-        valType !== "number" &&
-        valType !== "boolean"
-      ) {
-        continue;
-      }
-
-      const strVal = String(value);
-
-      if (key.endsWith("_100g")) {
-        if (nutritionDataPer !== "100g") continue;
-        const nid = key.slice(0, -"_100g".length);
-        params[`nutriment_${nid}`] = strVal;
-      } else if (key.endsWith("_serving")) {
-        if (nutritionDataPer !== "serving") continue;
-        const nid = key.slice(0, -"_serving".length);
-        params[`nutriment_${nid}`] = strVal;
-      } else if (key.endsWith("_unit")) {
-        const nid = key.slice(0, -"_unit".length);
-        params[`nutriment_${nid}_unit`] = strVal;
-      } else if (key.endsWith("_modifier")) {
-        const nid = key.slice(0, -"_modifier".length);
-        params[`nutriment_${nid}_modifier`] = strVal;
+      if (this.isPrimitiveValue(value)) {
+        this.processNutrimentEntry(key, value, nutritionDataPer, params);
       }
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,70 @@
+import type { NutritionDataPer } from "./off-v2.js";
+
+export function isPrimitiveValue(
+  value: unknown,
+): value is string | number | boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  const valType = typeof value;
+  return valType === "string" || valType === "number" || valType === "boolean";
+}
+
+export function getNutritionDataPer(
+  nutriments: Record<string, unknown>,
+): NutritionDataPer | undefined {
+  let nutritionDataPer: NutritionDataPer | undefined;
+  for (const [key, value] of Object.entries(nutriments)) {
+    if (!isPrimitiveValue(value)) continue;
+
+    if (key.endsWith("_100g")) {
+      return "100g";
+    }
+    if (key.endsWith("_serving")) {
+      nutritionDataPer = "serving";
+    }
+  }
+  return nutritionDataPer;
+}
+
+export function processNutrimentEntry(
+  key: string,
+  value: string | number | boolean,
+  nutritionDataPer: NutritionDataPer | undefined,
+  params: Record<string, string>,
+): void {
+  const strVal = String(value);
+
+  if (key.endsWith("_100g") && nutritionDataPer === "100g") {
+    const nid = key.slice(0, -5);
+    params[`nutriment_${nid}`] = strVal;
+  } else if (key.endsWith("_serving") && nutritionDataPer === "serving") {
+    const nid = key.slice(0, -8);
+    params[`nutriment_${nid}`] = strVal;
+  } else if (key.endsWith("_unit")) {
+    const nid = key.slice(0, -5);
+    params[`nutriment_${nid}_unit`] = strVal;
+  } else if (key.endsWith("_modifier")) {
+    const nid = key.slice(0, -9);
+    params[`nutriment_${nid}_modifier`] = strVal;
+  }
+}
+
+export function buildNutritionParams(
+  nutriments: Record<string, unknown>,
+): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  const nutritionDataPer = getNutritionDataPer(nutriments);
+  if (nutritionDataPer) {
+    params["nutrition_data_per"] = nutritionDataPer;
+  }
+
+  for (const [key, value] of Object.entries(nutriments)) {
+    if (isPrimitiveValue(value)) {
+      processNutrimentEntry(key, value, nutritionDataPer, params);
+    }
+  }
+
+  return params;
+}

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -671,6 +671,28 @@ describe("OpenFoodFacts", () => {
       expect(body.get("nutrition_data_per")).toBe("serving");
       expect(body.get("nutriment_sugars")).toBe("5");
     });
+
+    it("should fallback to serving when 100g keys contain only non-serializable data", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithInvalid100g = {
+        ...baseProductData,
+        nutriments: {
+          fat_100g: { invalid: "object" },
+          sugars_serving: 5,
+        },
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithInvalid100g,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutrition_data_per")).toBe("serving");
+      expect(body.get("nutriment_fat")).toBeNull();
+      expect(body.get("nutriment_sugars")).toBe("5");
+    });
   });
 
   describe("getProductImageUrl", () => {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -608,6 +608,69 @@ describe("OpenFoodFacts", () => {
       expect(body.get("nutriment_fat")).toBe("20");
       expect(body.get("nutriment_fat_modifier")).toBe("<");
     });
+
+    it("should skip non-primitive nutriment values", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithInvalidVal = {
+        ...baseProductData,
+        nutriments: {
+          fat_100g: 20,
+          sugars_100g: { nested: "object" },
+          salt_100g: [1, 2],
+        },
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithInvalidVal,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutriment_fat")).toBe("20");
+      expect(body.get("nutriment_sugars")).toBeNull();
+      expect(body.get("nutriment_salt")).toBeNull();
+    });
+
+    it("should handle mixed _100g and _serving inputs deterministically preferring 100g", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithMixed = {
+        ...baseProductData,
+        nutriments: {
+          fat_100g: 20,
+          sugars_serving: 5,
+        },
+      };
+
+      await productsApi.addOrEditProductV2(productWithMixed, testCredentials);
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutrition_data_per")).toBe("100g");
+      expect(body.get("nutriment_fat")).toBe("20");
+      // Sugars per serving should be ignored because nutrition_data_per is 100g
+      expect(body.get("nutriment_sugars")).toBeNull();
+    });
+
+    it("should handle mixed inputs deterministically preferring serving when no 100g keys exist", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithMixedServing = {
+        ...baseProductData,
+        nutriments: {
+          sugars_serving: 5,
+        },
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithMixedServing,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutrition_data_per")).toBe("serving");
+      expect(body.get("nutriment_sugars")).toBe("5");
+    });
   });
 
   describe("getProductImageUrl", () => {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -498,6 +498,116 @@ describe("OpenFoodFacts", () => {
 
       expect(result).toBe(false);
     });
+
+    it("should include nutriment parameters when nutrition data is present", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithNutrients = {
+        ...baseProductData,
+        nutriments: {
+          fat_100g: 20,
+          sugars_100g: 5,
+          salt_100g: 1.2,
+          fat_unit: "g",
+        },
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithNutrients,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutriment_fat")).toBe("20");
+      expect(body.get("nutriment_sugars")).toBe("5");
+      expect(body.get("nutriment_salt")).toBe("1.2");
+      expect(body.get("nutriment_fat_unit")).toBe("g");
+      expect(body.get("nutrition_data_per")).toBe("100g");
+      expect(body.get("no_nutrition_data")).toBe("");
+    });
+
+    it("should set nutrition_data_per to serving for per-serving values", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithServing = {
+        ...baseProductData,
+        serving_size: "30g",
+        nutriments: {
+          fat_serving: 6,
+          sugars_serving: 1.5,
+        },
+      };
+
+      await productsApi.addOrEditProductV2(productWithServing, testCredentials);
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutriment_fat")).toBe("6");
+      expect(body.get("nutriment_sugars")).toBe("1.5");
+      expect(body.get("nutrition_data_per")).toBe("serving");
+    });
+
+    it("should preserve empty strings for nutriment deletion", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithDeletion = {
+        ...baseProductData,
+        nutriments: {
+          fat_100g: 20,
+          sugars_100g: "",
+        },
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithDeletion,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutriment_fat")).toBe("20");
+      expect(body.get("nutriment_sugars")).toBe("");
+    });
+
+    it("should skip nutriment parameters when no_nutrition_data is true", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productNoNutrition = {
+        ...baseProductData,
+        no_nutrition_data: true,
+        nutriments: {
+          fat_100g: 20,
+          sugars_100g: 5,
+        },
+      };
+
+      await productsApi.addOrEditProductV2(productNoNutrition, testCredentials);
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("no_nutrition_data")).toBe("on");
+      expect(body.get("nutriment_fat")).toBeNull();
+      expect(body.get("nutriment_sugars")).toBeNull();
+      expect(body.get("nutrition_data_per")).toBeNull();
+    });
+
+    it("should include modifier parameters", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithModifier = {
+        ...baseProductData,
+        nutriments: {
+          fat_100g: 20,
+          fat_modifier: "<",
+        },
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithModifier,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("nutriment_fat")).toBe("20");
+      expect(body.get("nutriment_fat_modifier")).toBe("<");
+    });
   });
 
   describe("getProductImageUrl", () => {


### PR DESCRIPTION
### What
Translates nested nutrient parameters (e.g. `fat_100g`, `fat_serving`, `fat_unit`, `fat_modifier`) inside `product.nutriments` into the flat `nutriment_*` CGI parameters expected by the legacy Perl backend during edit requests.

- Added `buildNutritionParams` helper to flatten `product.nutriments` properties and set `nutrition_data_per` where applicable.
- Updated `addOrEditProductV2` to call this helper and merge the flat parameters when `no_nutrition_data` is false.
- Added tests ensuring nutriments are mapped per 100g, per serving, modifiers and units are handled, and empty strings are preserved for field deletions.


### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1387


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a nutrition-parsing utility and exported per‑unit type to build nutrition parameters for product submissions.

* **Refactor**
  * Product submission now conditionally includes, omits, or clears nutriment fields, selects per‑unit indicator (prefers 100g when applicable), and respects the no‑nutrition toggle while merging computed nutrition parameters.

* **Tests**
  * Expanded tests for per‑unit selection, deletions, modifiers, skipping non‑primitive values, fallback rules, and no‑nutrition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->