### PR TITLE
feat: add missing allergens and traces fields 

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -173,6 +173,8 @@ export class ProductOpenerApiV2 {
       stores: product.stores || "",
       origins: product.origins || "",
       countries: product.countries || "",
+      allergens: product.allergens || "",
+      traces: product.traces || "",
       emb_codes: product.emb_codes || "",
       packaging: product.packaging || "",
       manufacturing_places: product.manufacturing_places || "",

--- a/src/off-v3.ts
+++ b/src/off-v3.ts
@@ -104,6 +104,11 @@ export type ProductDataType = ProductDataSection & {
   labels_tags: string[];
   product_type: string;
 
+  allergens?: string;
+  allergens_tags?: string[];
+  traces?: string;
+  traces_tags?: string[];
+
   origins: string;
   origins_tags: string[];
 


### PR DESCRIPTION
### What
- Exposed the missing allergens and traces fields and its tags (`allergens`, `allergens_tags`, `traces`, `traces_tags`) 
- Mapped them to the payload of the product edit API endpoint

### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1346


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added allergen and trace information fields to product submissions and data storage.
  * Allergen and trace tags now supported for improved product details and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->