### PR TITLE
ci: Update Node.js versions in CI matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 23.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Remove 20.x (EOL since April 30, 2026) and 23.x (EOL since June 1, 2025), add 26.x
