### PR TITLE
feat(moderator): add moveImages and deleteImages API method

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -392,25 +392,63 @@ export class ProductOpenerApiV2 {
   }
 
   /**
-   * Move images from one product to another, or to trash (delete).
-   * Moderator-only action.
+   * Move images from one product to another (moderator-only action)
    * @param code - source product barcode
    * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
-   * @param moveTo - destination product barcode OR "trash" to delete
+   * @param moveToBarcode - destination product barcode
    * @param copyData - whether to copy product data to destination
+   * @returns A promise that resolves to true if successful, false otherwise
    */
-  async moveOrDeleteImages(
+  async moveImages(
     code: string,
     imgids: string,
-    moveTo: string,
+    moveToBarcode: string,
     copyData: boolean = false,
   ): Promise<boolean> {
+    if (!code || code.trim().length === 0) {
+      throw new Error("A non-empty source product barcode is required.");
+    }
+    if (!imgids || imgids.trim().length === 0) {
+      throw new Error("A non-empty list of image IDs is required.");
+    }
+    if (!moveToBarcode || moveToBarcode.trim().length === 0) {
+      throw new Error("A non-empty destination product barcode is required.");
+    }
     const url = `${this.baseUrl}/cgi/product_image_move.pl`;
     const body = formData({
-      code: code,
-      imgids: imgids,
-      move_to_override: moveTo,
+      code,
+      imgids,
+      move_to_override: moveToBarcode,
       copy_data_override: copyData ? "true" : "false",
+    });
+
+    const res = await this.fetch(url, {
+      method: "POST",
+      body,
+    });
+
+    return res.status === 200;
+  }
+
+  /**
+   * Delete product images by moving them to trash (moderator-only action)
+   * @param code - product barcode
+   * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
+   * @returns A promise that resolves to true if successful, false otherwise
+   */
+  async deleteImages(code: string, imgids: string): Promise<boolean> {
+    if (!code || code.trim().length === 0) {
+      throw new Error("A non-empty product barcode is required.");
+    }
+    if (!imgids || imgids.trim().length === 0) {
+      throw new Error("A non-empty list of image IDs is required.");
+    }
+    const url = `${this.baseUrl}/cgi/product_image_move.pl`;
+    const body = formData({
+      code,
+      imgids,
+      move_to_override: "trash",
+      copy_data_override: "false",
     });
 
     const res = await this.fetch(url, {

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -422,12 +422,16 @@ export class ProductOpenerApiV2 {
       copy_data_override: copyData ? "true" : "false",
     });
 
-    const res = await this.fetch(url, {
-      method: "POST",
-      body,
-    });
+    try {
+      const res = await this.fetch(url, {
+        method: "POST",
+        body,
+      });
 
-    return res.status === 200;
+      return res.status === 200;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -451,12 +455,16 @@ export class ProductOpenerApiV2 {
       copy_data_override: "false",
     });
 
-    const res = await this.fetch(url, {
-      method: "POST",
-      body,
-    });
+    try {
+      const res = await this.fetch(url, {
+        method: "POST",
+        body,
+      });
 
-    return res.status === 200;
+      return res.status === 200;
+    } catch {
+      return false;
+    }
   }
 }
 

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -390,6 +390,36 @@ export class ProductOpenerApiV2 {
 
     return res.status === 200;
   }
+
+  /**
+   * Move images from one product to another, or to trash (delete).
+   * Moderator-only action.
+   * @param code - source product barcode
+   * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
+   * @param moveTo - destination product barcode OR "trash" to delete
+   * @param copyData - whether to copy product data to destination
+   */
+  async moveOrDeleteImages(
+    code: string,
+    imgids: string,
+    moveTo: string,
+    copyData: boolean = false,
+  ): Promise<boolean> {
+    const url = `${this.baseUrl}/cgi/product_image_move.pl`;
+    const body = formData({
+      code: code,
+      imgids: imgids,
+      move_to_override: moveTo,
+      copy_data_override: copyData ? "true" : "false",
+    });
+
+    const res = await this.fetch(url, {
+      method: "POST",
+      body,
+    });
+
+    return res.status === 200;
+  }
 }
 
 export function getProductNameInLang(product: ProductDataType, lang: string) {

--- a/src/off.ts
+++ b/src/off.ts
@@ -632,6 +632,22 @@ export class OpenFoodFacts {
   deleteProduct = (code: string, comment: string) =>
     this.apiv2.deleteProduct(code, comment);
 
+  /**
+   * Move images from one product to another, or to trash (delete).
+   * Moderator-only action.
+   * @param code - source product barcode
+   * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
+   * @param moveTo - destination product barcode OR "trash" to delete
+   * @param copyData - whether to copy product data to destination
+   * @returns A promise that resolves to true if successful, false otherwise
+   */
+  moveOrDeleteImages = (
+    code: string,
+    imgids: string,
+    moveTo: string,
+    copyData?: boolean,
+  ) => this.apiv2.moveOrDeleteImages(code, imgids, moveTo, copyData);
+
   async getFacet(
     facet: string,
     opts?: { page?: number; pageSize?: number; sortBy?: FacetSortOption },

--- a/src/off.ts
+++ b/src/off.ts
@@ -633,20 +633,28 @@ export class OpenFoodFacts {
     this.apiv2.deleteProduct(code, comment);
 
   /**
-   * Move images from one product to another, or to trash (delete).
-   * Moderator-only action.
+   * Move images from one product to another (moderator-only action).
    * @param code - source product barcode
    * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
-   * @param moveTo - destination product barcode OR "trash" to delete
+   * @param moveToBarcode - destination product barcode
    * @param copyData - whether to copy product data to destination
    * @returns A promise that resolves to true if successful, false otherwise
    */
-  moveOrDeleteImages = (
+  moveImages = (
     code: string,
     imgids: string,
-    moveTo: string,
+    moveToBarcode: string,
     copyData?: boolean,
-  ) => this.apiv2.moveOrDeleteImages(code, imgids, moveTo, copyData);
+  ) => this.apiv2.moveImages(code, imgids, moveToBarcode, copyData);
+
+  /**
+   * Delete product images by moving them to trash (moderator-only action).
+   * @param code - product barcode
+   * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
+   * @returns A promise that resolves to true if successful, false otherwise
+   */
+  deleteImages = (code: string, imgids: string) =>
+    this.apiv2.deleteImages(code, imgids);
 
   async getFacet(
     facet: string,

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -731,6 +731,23 @@ describe("OpenFoodFacts", () => {
     });
   });
 
+  const verifyImageMoveRequest = (
+    expectedMoveTo: string,
+    expectedCopyData: string,
+  ) => {
+    expect(mockFetch).toHaveBeenCalled();
+    const [url, options] = mockFetch.mock.calls[0] as [string, any];
+    expect(url).toBe(
+      "https://world.openfoodfacts.org/cgi/product_image_move.pl",
+    );
+    expect(options.method).toBe("POST");
+    const formDataBody = options.body as FormData;
+    expect(formDataBody.get("code")).toBe("123456");
+    expect(formDataBody.get("imgids")).toBe("1,2");
+    expect(formDataBody.get("move_to_override")).toBe(expectedMoveTo);
+    expect(formDataBody.get("copy_data_override")).toBe(expectedCopyData);
+  };
+
   describe("moveImages", () => {
     it("should successfully move images", async () => {
       mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
@@ -743,17 +760,15 @@ describe("OpenFoodFacts", () => {
       );
 
       expect(result).toBe(true);
-      expect(mockFetch).toHaveBeenCalled();
-      const [url, options] = mockFetch.mock.calls[0] as [string, any];
-      expect(url).toBe(
-        "https://world.openfoodfacts.org/cgi/product_image_move.pl",
-      );
-      expect(options.method).toBe("POST");
-      const formDataBody = options.body as FormData;
-      expect(formDataBody.get("code")).toBe("123456");
-      expect(formDataBody.get("imgids")).toBe("1,2");
-      expect(formDataBody.get("move_to_override")).toBe("654321");
-      expect(formDataBody.get("copy_data_override")).toBe("true");
+    });
+
+    it("should successfully move images with default copyData=false", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const result = await productsApi.moveImages("123456", "1,2", "654321");
+
+      expect(result).toBe(true);
+      verifyImageMoveRequest("654321", "false");
     });
 
     it("should return false when moving images request fails", async () => {
@@ -784,17 +799,7 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.deleteImages("123456", "1,2");
 
       expect(result).toBe(true);
-      expect(mockFetch).toHaveBeenCalled();
-      const [url, options] = mockFetch.mock.calls[0] as [string, any];
-      expect(url).toBe(
-        "https://world.openfoodfacts.org/cgi/product_image_move.pl",
-      );
-      expect(options.method).toBe("POST");
-      const formDataBody = options.body as FormData;
-      expect(formDataBody.get("code")).toBe("123456");
-      expect(formDataBody.get("imgids")).toBe("1,2");
-      expect(formDataBody.get("move_to_override")).toBe("trash");
-      expect(formDataBody.get("copy_data_override")).toBe("false");
+      verifyImageMoveRequest("trash", "false");
     });
 
     it("should return false when deleting images request fails", async () => {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -731,6 +731,40 @@ describe("OpenFoodFacts", () => {
     });
   });
 
+  describe("moveOrDeleteImages", () => {
+    it("should successfully move/delete images", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const result = await productsApi.moveOrDeleteImages(
+        "123456",
+        "1,2",
+        "trash",
+        true,
+      );
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://world.openfoodfacts.org/cgi/product_image_move.pl",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.any(FormData),
+        }),
+      );
+    });
+
+    it("should return false when the request fails", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
+
+      const result = await productsApi.moveOrDeleteImages(
+        "123456",
+        "1,2",
+        "trash",
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe("getProductImageUrl", () => {
     const mockSelectedImage = {
       front: {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -731,37 +731,87 @@ describe("OpenFoodFacts", () => {
     });
   });
 
-  describe("moveOrDeleteImages", () => {
-    it("should successfully move/delete images", async () => {
+  describe("moveImages", () => {
+    it("should successfully move images", async () => {
       mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
 
-      const result = await productsApi.moveOrDeleteImages(
+      const result = await productsApi.moveImages(
         "123456",
         "1,2",
-        "trash",
+        "654321",
         true,
       );
 
       expect(result).toBe(true);
-      expect(mockFetch).toHaveBeenCalledWith(
+      expect(mockFetch).toHaveBeenCalled();
+      const [url, options] = mockFetch.mock.calls[0] as [string, any];
+      expect(url).toBe(
         "https://world.openfoodfacts.org/cgi/product_image_move.pl",
-        expect.objectContaining({
-          method: "POST",
-          body: expect.any(FormData),
-        }),
       );
+      expect(options.method).toBe("POST");
+      const formDataBody = options.body as FormData;
+      expect(formDataBody.get("code")).toBe("123456");
+      expect(formDataBody.get("imgids")).toBe("1,2");
+      expect(formDataBody.get("move_to_override")).toBe("654321");
+      expect(formDataBody.get("copy_data_override")).toBe("true");
     });
 
-    it("should return false when the request fails", async () => {
+    it("should return false when moving images request fails", async () => {
       mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
 
-      const result = await productsApi.moveOrDeleteImages(
-        "123456",
-        "1,2",
-        "trash",
-      );
+      const result = await productsApi.moveImages("123456", "1,2", "654321");
 
       expect(result).toBe(false);
+    });
+
+    it("should throw an error if any required parameter is empty or whitespace", async () => {
+      await expect(productsApi.moveImages("", "1,2", "654321")).rejects.toThrow(
+        "A non-empty source product barcode is required.",
+      );
+      await expect(
+        productsApi.moveImages("123456", "   ", "654321"),
+      ).rejects.toThrow("A non-empty list of image IDs is required.");
+      await expect(productsApi.moveImages("123456", "1,2", "")).rejects.toThrow(
+        "A non-empty destination product barcode is required.",
+      );
+    });
+  });
+
+  describe("deleteImages", () => {
+    it("should successfully delete images (move to trash)", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const result = await productsApi.deleteImages("123456", "1,2");
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalled();
+      const [url, options] = mockFetch.mock.calls[0] as [string, any];
+      expect(url).toBe(
+        "https://world.openfoodfacts.org/cgi/product_image_move.pl",
+      );
+      expect(options.method).toBe("POST");
+      const formDataBody = options.body as FormData;
+      expect(formDataBody.get("code")).toBe("123456");
+      expect(formDataBody.get("imgids")).toBe("1,2");
+      expect(formDataBody.get("move_to_override")).toBe("trash");
+      expect(formDataBody.get("copy_data_override")).toBe("false");
+    });
+
+    it("should return false when deleting images request fails", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
+
+      const result = await productsApi.deleteImages("123456", "1,2");
+
+      expect(result).toBe(false);
+    });
+
+    it("should throw an error if any required parameter is empty or whitespace", async () => {
+      await expect(productsApi.deleteImages("", "1,2")).rejects.toThrow(
+        "A non-empty product barcode is required.",
+      );
+      await expect(productsApi.deleteImages("123456", "  ")).rejects.toThrow(
+        "A non-empty list of image IDs is required.",
+      );
     });
   });
 


### PR DESCRIPTION
### What
- Added two new moderator-only API methods `moveImages` and `deleteImages` to interact with `/cgi/product_image_move.pl`
- Supports moving images from a source product to a destination product or to the trash (deletion)


### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/810


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moderators can move images between products (optionally preserving associated copy data) or remove images by moving them to trash. Operations indicate success/failure so callers can respond accordingly and will reject empty/whitespace product barcodes or image-id lists.

* **Tests**
  * Added coverage for image-move and image-delete flows: successful cases (with/without copy), failure handling, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->