### PR TITLE
feat(moderator): add deleteProduct API method

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -351,6 +351,29 @@ export class ProductOpenerApiV2 {
 
     return res.response.ok;
   }
+
+  /**
+   * Delete a product page (moderator-only action)
+   * @param code - product barcode
+   * @param comment - reason for deletion
+   * @returns A promise that resolves to true if successful, false otherwise
+   */
+  async deleteProduct(code: string, comment: string): Promise<boolean> {
+    const url = `${this.baseUrl}/cgi/product.pl`;
+    const body = formData({
+      type: "delete",
+      action: "process",
+      code,
+      comment,
+    });
+
+    const res = await this.fetch(url, {
+      method: "POST",
+      body,
+    });
+
+    return res.status === 200;
+  }
 }
 
 export function getProductNameInLang(product: ProductDataType, lang: string) {

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -359,6 +359,9 @@ export class ProductOpenerApiV2 {
    * @returns A promise that resolves to true if successful, false otherwise
    */
   async deleteProduct(code: string, comment: string): Promise<boolean> {
+    if (!comment || comment.trim().length === 0) {
+      throw new Error("A non-empty deletion comment is required.");
+    }
     const url = `${this.baseUrl}/cgi/product.pl`;
     const body = formData({
       type: "delete",

--- a/src/off.ts
+++ b/src/off.ts
@@ -623,6 +623,15 @@ export class OpenFoodFacts {
    */
   getProductImages = (barcode: string) => this.apiv2.getProductImages(barcode);
 
+  /**
+   * Delete a product page (moderator-only action)
+   * @param code - The barcode of the product to delete
+   * @param comment - The reason for deleting the product
+   * @returns A promise that resolves to true if successful, false otherwise
+   */
+  deleteProduct = (code: string, comment: string) =>
+    this.apiv2.deleteProduct(code, comment);
+
   async getFacet(
     facet: string,
     opts?: { page?: number; pageSize?: number; sortBy?: FacetSortOption },

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -507,13 +507,15 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.deleteProduct("123456", "test deletion");
 
       expect(result).toBe(true);
-      expect(mockFetch).toHaveBeenCalledWith(
-        "https://world.openfoodfacts.org/cgi/product.pl",
-        expect.objectContaining({
-          method: "POST",
-          body: expect.any(FormData),
-        }),
-      );
+      expect(mockFetch).toHaveBeenCalled();
+      const [url, options] = mockFetch.mock.calls[0] as [string, any];
+      expect(url).toBe("https://world.openfoodfacts.org/cgi/product.pl");
+      expect(options.method).toBe("POST");
+      const formDataBody = options.body as FormData;
+      expect(formDataBody.get("type")).toBe("delete");
+      expect(formDataBody.get("action")).toBe("process");
+      expect(formDataBody.get("code")).toBe("123456");
+      expect(formDataBody.get("comment")).toBe("test deletion");
     });
 
     it("should return false when deletion request fails", async () => {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -500,6 +500,31 @@ describe("OpenFoodFacts", () => {
     });
   });
 
+  describe("deleteProduct", () => {
+    it("should successfully delete a product", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const result = await productsApi.deleteProduct("123456", "test deletion");
+
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://world.openfoodfacts.org/cgi/product.pl",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.any(FormData),
+        }),
+      );
+    });
+
+    it("should return false when deletion request fails", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
+
+      const result = await productsApi.deleteProduct("123456", "test deletion");
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe("getProductImageUrl", () => {
     const mockSelectedImage = {
       front: {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -523,6 +523,15 @@ describe("OpenFoodFacts", () => {
 
       expect(result).toBe(false);
     });
+
+    it("should throw an error if the deletion comment is empty or whitespace", async () => {
+      await expect(productsApi.deleteProduct("123456", "")).rejects.toThrow(
+        "A non-empty deletion comment is required.",
+      );
+      await expect(productsApi.deleteProduct("123456", "   ")).rejects.toThrow(
+        "A non-empty deletion comment is required.",
+      );
+    });
   });
 
   describe("getProductImageUrl", () => {


### PR DESCRIPTION
### What
- Adds a new moderator-only API method `deleteProduct` to interact with `/cgi/product.pl`
- Supports permanently deleting product pages with a required reason comment.

### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/810


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Moderators can delete products via the API. A non-empty deletion comment is required; successful deletions return true, non-200 responses return false. Enhances moderation workflow and accountability.

* **Tests**
  * Added tests covering successful deletion, failed deletion responses, and validation rejecting empty or whitespace-only deletion comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->