### PR TITLE
refactor: extract shared productImageMove helper for image move/trash ops

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -397,14 +397,24 @@ export class ProductOpenerApiV2 {
    * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
    * @param moveToBarcode - destination product barcode
    * @param copyData - whether to copy product data to destination
-   * @returns A promise that resolves to true if successful, false otherwise
+   * @returns A promise that resolves with `{ data }` on success or `{ error }` on failure
+   * @example
+   * const result = await moveImages("12345", "1,2,3", "54321", true);
+   * if ("error" in result) {
+   *   console.error("Failed to move images:", result.error);
+   * } else {
+   *   console.log("Images moved successfully:", result.data);
+   * }
    */
   async moveImages(
     code: string,
     imgids: string,
     moveToBarcode: string,
     copyData: boolean = false,
-  ): Promise<boolean> {
+  ): Promise<
+    | { error: Error; response?: Response }
+    | { data: unknown; response?: Response }
+  > {
     if (!code || code.trim().length === 0) {
       throw new Error("A non-empty source product barcode is required.");
     }
@@ -414,45 +424,70 @@ export class ProductOpenerApiV2 {
     if (!moveToBarcode || moveToBarcode.trim().length === 0) {
       throw new Error("A non-empty destination product barcode is required.");
     }
-    const url = `${this.baseUrl}/cgi/product_image_move.pl`;
-    const body = formData({
-      code,
+
+    return this.productImageMove(code, {
       imgids,
-      move_to_override: moveToBarcode,
-      copy_data_override: copyData ? "true" : "false",
+      moveToOverride: moveToBarcode,
+      copyDataOverride: copyData,
     });
-
-    try {
-      const res = await this.fetch(url, {
-        method: "POST",
-        body,
-      });
-
-      return res.status === 200;
-    } catch {
-      return false;
-    }
   }
 
   /**
    * Delete product images by moving them to trash (moderator-only action)
    * @param code - product barcode
    * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
-   * @returns A promise that resolves to true if successful, false otherwise
+   * @returns A promise that resolves with `{ data }` on success or `{ error }` on failure
+   * @example
+   * const result = await deleteImages("12345", "1,2,3");
+   * if ("error" in result) {
+   *   console.error("Failed to delete images:", result.error);
+   * } else {
+   *   console.log("Images deleted successfully:", result.data);
+   * }
    */
-  async deleteImages(code: string, imgids: string): Promise<boolean> {
+  async deleteImages(
+    code: string,
+    imgids: string,
+  ): Promise<
+    | { error: Error; response?: Response }
+    | { data: unknown; response?: Response }
+  > {
     if (!code || code.trim().length === 0) {
       throw new Error("A non-empty product barcode is required.");
     }
     if (!imgids || imgids.trim().length === 0) {
       throw new Error("A non-empty list of image IDs is required.");
     }
+
+    return this.productImageMove(code, {
+      imgids,
+      moveToOverride: "trash",
+      copyDataOverride: false,
+    });
+  }
+
+  /**
+   * Calls /cgi/product_image_move.pl to move or delete images, depending on the
+   * parameters.
+   */
+  private async productImageMove(
+    code: string,
+    options: {
+      imgids: string;
+      moveToOverride: string;
+      copyDataOverride: boolean;
+    },
+  ): Promise<
+    | { error: Error; response?: Response }
+    | { data: unknown; response?: Response }
+  > {
     const url = `${this.baseUrl}/cgi/product_image_move.pl`;
+
     const body = formData({
       code,
-      imgids,
-      move_to_override: "trash",
-      copy_data_override: "false",
+      imgids: options.imgids,
+      move_to_override: options.moveToOverride,
+      copy_data_override: options.copyDataOverride ? "true" : "false",
     });
 
     try {
@@ -461,9 +496,18 @@ export class ProductOpenerApiV2 {
         body,
       });
 
-      return res.status === 200;
+      if (!res.ok) {
+        return {
+          response: res,
+          error: new Error(`Failed to move images: ${res.statusText}`),
+        };
+      }
+
+      const json = await res.json();
+
+      return { data: json, response: res };
     } catch {
-      return false;
+      return { response: undefined, error: new Error("Failed to move images") };
     }
   }
 }

--- a/src/off.ts
+++ b/src/off.ts
@@ -638,7 +638,7 @@ export class OpenFoodFacts {
    * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
    * @param moveToBarcode - destination product barcode
    * @param copyData - whether to copy product data to destination
-   * @returns A promise that resolves to true if successful, false otherwise
+   * @returns A promise that resolves with `{ data }` on success or `{ error }` on failure
    */
   moveImages = (
     code: string,
@@ -651,7 +651,7 @@ export class OpenFoodFacts {
    * Delete product images by moving them to trash (moderator-only action).
    * @param code - product barcode
    * @param imgids - comma-separated list of image IDs (e.g., "1,2,3")
-   * @returns A promise that resolves to true if successful, false otherwise
+   * @returns A promise that resolves with `{ data }` on success or `{ error }` on failure
    */
   deleteImages = (code: string, imgids: string) =>
     this.apiv2.deleteImages(code, imgids);

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -769,6 +769,7 @@ describe("OpenFoodFacts", () => {
       const result = await productsApi.moveImages("123456", "1,2", "654321");
 
       expect("data" in result).toBe(true);
+      expect("error" in result).toBe(false);
       verifyImageMoveRequest("654321", "false");
     });
 
@@ -779,6 +780,15 @@ describe("OpenFoodFacts", () => {
 
       expect("error" in result).toBe(true);
       expect("data" in result).toBe(false);
+    });
+    it("should return error when fetch rejects", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      const result = await productsApi.moveImages("123456", "1,2", "654321");
+
+      expect("error" in result).toBe(true);
+      expect("data" in result).toBe(false);
+      expect(result.response).toBeUndefined();
     });
 
     it("should throw an error if any required parameter is empty or whitespace", async () => {
@@ -812,6 +822,15 @@ describe("OpenFoodFacts", () => {
 
       expect("error" in result).toBe(true);
       expect("data" in result).toBe(false);
+    });
+    it("should return error when fetch rejects", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      const result = await productsApi.deleteImages("123456", "1,2");
+
+      expect("error" in result).toBe(true);
+      expect("data" in result).toBe(false);
+      expect(result.response).toBeUndefined();
     });
 
     it("should throw an error if any required parameter is empty or whitespace", async () => {

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -759,7 +759,8 @@ describe("OpenFoodFacts", () => {
         true,
       );
 
-      expect(result).toBe(true);
+      expect("data" in result).toBe(true);
+      expect("error" in result).toBe(false);
     });
 
     it("should successfully move images with default copyData=false", async () => {
@@ -767,16 +768,17 @@ describe("OpenFoodFacts", () => {
 
       const result = await productsApi.moveImages("123456", "1,2", "654321");
 
-      expect(result).toBe(true);
+      expect("data" in result).toBe(true);
       verifyImageMoveRequest("654321", "false");
     });
 
-    it("should return false when moving images request fails", async () => {
+    it("should return error when moving images request fails", async () => {
       mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
 
       const result = await productsApi.moveImages("123456", "1,2", "654321");
 
-      expect(result).toBe(false);
+      expect("error" in result).toBe(true);
+      expect("data" in result).toBe(false);
     });
 
     it("should throw an error if any required parameter is empty or whitespace", async () => {
@@ -798,16 +800,18 @@ describe("OpenFoodFacts", () => {
 
       const result = await productsApi.deleteImages("123456", "1,2");
 
-      expect(result).toBe(true);
+      expect("data" in result).toBe(true);
+      expect("error" in result).toBe(false);
       verifyImageMoveRequest("trash", "false");
     });
 
-    it("should return false when deleting images request fails", async () => {
+    it("should return error when deleting images request fails", async () => {
       mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
 
       const result = await productsApi.deleteImages("123456", "1,2");
 
-      expect(result).toBe(false);
+      expect("error" in result).toBe(true);
+      expect("data" in result).toBe(false);
     });
 
     it("should throw an error if any required parameter is empty or whitespace", async () => {


### PR DESCRIPTION
## Summary

Refactors the image move and trash operations in \`ProductOpenerApiV2\` by extracting the common \`/cgi/product_image_move.pl\` POST logic into a shared private helper.

## Motivation

- Eliminates code duplication (~15 lines).
- Single point of change for the image move endpoint.
- Structured return type allows callers to distinguish network errors from non-200 responses in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated image move and delete operations to return structured results: success includes returned data; failures include detailed error information and, when available, the HTTP response.
  * Centralized the underlying image request handling for consistent form submission and response parsing.
* **Documentation**
  * Revised return documentation to reflect the new `{ data }` vs `{ error }` result shape.
* **Tests**
  * Adjusted unit tests to validate object-shaped results for success, HTTP failure, and fetch-rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->