### PR TITLE
feat: add generic name and official website URL fields to product

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -164,6 +164,17 @@ export class ProductOpenerApiV2 {
       {} as Record<string, string>,
     );
 
+    const genericNames = languageCodes.reduce(
+      (acc, lang) => {
+        const genericName = getGenericNameInLang(product, lang);
+        if (genericName != null) {
+          acc[`generic_name_${lang}`] = genericName;
+        }
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+
     const noNutrition = product.no_nutrition_data === true;
 
     // When no_nutrition_data is checked, the server handles clearing nutriments.
@@ -191,11 +202,13 @@ export class ProductOpenerApiV2 {
       packaging: product.packaging || "",
       manufacturing_places: product.manufacturing_places || "",
       comment: product.comment ?? "",
+      link: product.link || "",
       product_name: product.product_name || "",
       ingredients_text: product.ingredients_text || "",
       no_nutrition_data: noNutrition ? "on" : "",
       ...productNames,
       ...ingredientsTexts,
+      ...genericNames,
       ...nutritionParams,
     });
 
@@ -521,4 +534,8 @@ export function getProductIngredientsInLang(
   lang: string,
 ) {
   return product[`ingredients_text_${lang}`] ?? product.ingredients_text;
+}
+
+export function getGenericNameInLang(product: ProductDataType, lang: string) {
+  return product[`generic_name_${lang}`];
 }

--- a/src/off-v3.ts
+++ b/src/off-v3.ts
@@ -5,6 +5,7 @@ import type {
   LangIngredient,
   LangProduct,
   LangPackagingText,
+  LangGenericName,
   RawImage,
   SelectedImage,
   FetchFn,
@@ -143,7 +144,12 @@ export type ProductDataType = ProductDataSection & {
   data_quality_errors_tags?: string[];
   data_quality_warnings_tags?: string[];
   data_quality_info_tags?: string[];
-} & Partial<Record<LangProduct | LangIngredient | LangPackagingText, string>>;
+} & Partial<
+    Record<
+      LangProduct | LangIngredient | LangPackagingText | LangGenericName,
+      string
+    >
+  >;
 
 export type ProductStateBase = {
   result: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type LangIngredient = `ingredients_text_${string}`;
 export type LangProduct = `product_name_${string}`;
 export type LangPackagingText = `packaging_text_${string}`;
+export type LangGenericName = `generic_name_${string}`;
 
 export type ImageSize = { h: number; w: number };
 

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -482,6 +482,28 @@ describe("OpenFoodFacts", () => {
       );
     });
 
+    it("should include link and language-specific generic name parameters", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithUrlAndGeneric = {
+        ...baseProductData,
+        link: "https://example.com/producer-pasta",
+        languages_codes: { en: 1, fr: 1 },
+        generic_name_en: "Organic Pasta",
+        generic_name_fr: "Pâtes Biologiques",
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithUrlAndGeneric,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("link")).toBe("https://example.com/producer-pasta");
+      expect(body.get("generic_name_en")).toBe("Organic Pasta");
+      expect(body.get("generic_name_fr")).toBe("Pâtes Biologiques");
+    });
+
     it("should return false when request fails", async () => {
       mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
 


### PR DESCRIPTION
### What
- Adds support for dynamic, language-specific generic names (`generic_name_<lang>`) and the producer website URL (`link`) in product edits

### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/1363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product updates now include language-specific generic name fields when saving or editing products.
  * Support was expanded to recognize generic name values across localized product data.

* **Bug Fixes**
  * Requests now send generic name information correctly, so more product details are preserved during updates.

* **Tests**
  * Added coverage to verify that product links and localized generic names are included in outgoing update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->