### PR TITLE
fix: serialize cleared multilingual fields as empty strings

### DIFF
--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -141,7 +141,20 @@ export class ProductOpenerApiV2 {
   ): Promise<boolean> {
     const url = `${this.baseUrl}/cgi/product_jqm2.pl`;
 
-    const languageCodes = Object.keys(product.languages_codes || {});
+    const languageCodes = Array.from(
+      new Set([
+        ...Object.keys(product.languages_codes || {}),
+        ...Object.keys(product)
+          .map((key) =>
+            key.match(
+              /^(?:product_name|ingredients_text|generic_name)_([a-z]{2,3})$/,
+            ),
+          )
+          .filter((match): match is RegExpMatchArray => !!match)
+          .map((match) => match[1]),
+      ]),
+    );
+
     const productNames = languageCodes.reduce(
       (acc, lang) => {
         const productName = getProductNameInLang(product, lang);

--- a/src/off-v2.ts
+++ b/src/off-v2.ts
@@ -141,16 +141,17 @@ export class ProductOpenerApiV2 {
   ): Promise<boolean> {
     const url = `${this.baseUrl}/cgi/product_jqm2.pl`;
 
+    // Scan product keys to catch languages that were removed from `languages_codes` but still present as empty-string overrides
     const languageCodes = Array.from(
       new Set([
         ...Object.keys(product.languages_codes || {}),
         ...Object.keys(product)
           .map((key) =>
-            key.match(
-              /^(?:product_name|ingredients_text|generic_name)_([a-z]{2,3})$/,
+            /^(?:product_name|ingredients_text|generic_name)_([a-z]{2,3})$/.exec(
+              key,
             ),
           )
-          .filter((match): match is RegExpMatchArray => !!match)
+          .filter((match): match is RegExpExecArray => !!match)
           .map((match) => match[1]),
       ]),
     );

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -504,6 +504,27 @@ describe("OpenFoodFacts", () => {
       expect(body.get("generic_name_fr")).toBe("Pâtes Biologiques");
     });
 
+    it("should include language-specific parameters even when they are empty and not in languages_codes", async () => {
+      mockFetch.mockResolvedValue(TestUtils.mockResponse({}, true, 200));
+
+      const productWithDeletedLang = {
+        ...baseProductData,
+        languages_codes: { en: 1 },
+        product_name_fr: "",
+        ingredients_text_fr: "",
+      };
+
+      await productsApi.addOrEditProductV2(
+        productWithDeletedLang,
+        testCredentials,
+      );
+
+      const body = mockFetch.mock.calls[0]?.[1]?.body as FormData;
+      expect(body.get("product_name_en")).toBe("Test Product");
+      expect(body.get("product_name_fr")).toBe("");
+      expect(body.get("ingredients_text_fr")).toBe("");
+    });
+
     it("should return false when request fails", async () => {
       mockFetch.mockResolvedValue(TestUtils.mockResponse({}, false, 400));
 

--- a/tests/off.spec.ts
+++ b/tests/off.spec.ts
@@ -512,6 +512,7 @@ describe("OpenFoodFacts", () => {
         languages_codes: { en: 1 },
         product_name_fr: "",
         ingredients_text_fr: "",
+        generic_name_fr: "",
       };
 
       await productsApi.addOrEditProductV2(
@@ -523,6 +524,7 @@ describe("OpenFoodFacts", () => {
       expect(body.get("product_name_en")).toBe("Test Product");
       expect(body.get("product_name_fr")).toBe("");
       expect(body.get("ingredients_text_fr")).toBe("");
+      expect(body.get("generic_name_fr")).toBe("");
     });
 
     it("should return false when request fails", async () => {


### PR DESCRIPTION
### What
- Updates the V2 product edit serializer to detect and submit explicitly cleared (`""`) localized properties on the product payload so they are correctly wiped in the database

### Part of 
https://github.com/openfoodfacts/openfoodfacts-explorer/issues/309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multilingual product details so language-specific names, ingredients, and generic names are included more reliably in submissions.
  * Ensured language-specific fields can still be sent even when they are not listed in the product’s language set, helping preserve data during edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->