### PR TITLE
test: await folksonomy rejection assertions

### DIFF
--- a/tests/folksonomy.spec.ts
+++ b/tests/folksonomy.spec.ts
@@ -190,7 +190,7 @@ describe("Folksonomy Wrapper", () => {
   describe("Auth Token Validation", () => {
     it("should throw an error if auth token is missing and calling putTag", async () => {
       const clientWithoutToken = new Folksonomy(fetchMock);
-      expect(() =>
+      await expect(() =>
         clientWithoutToken.putTag({
           k: "key",
           v: "value",
@@ -212,7 +212,7 @@ describe("Folksonomy Wrapper", () => {
         comment: "Test comment",
         owner: "",
       };
-      expect(() => clientWithoutToken.removeTag(tagData)).rejects.toThrow(
+      await expect(() => clientWithoutToken.removeTag(tagData)).rejects.toThrow(
         "Auth token is required to perform this action",
       );
     });


### PR DESCRIPTION
## Summary

- Await asynchronous rejection assertions in the Folksonomy authentication tests.
- Remove Vitest warnings about unawaited assertions.

## Tests

- `yarn test`
- 225 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation coverage for auth token handling by ensuring missing-token errors are properly checked in async test cases.
  * Added awaited rejection assertions so error checks run reliably during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->