### PR TITLE
fix: Revert "chore(deps): bump brace-expansion from 5.0.6 to 5.0.9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "vitest": "^4.1.9"
   },
   "resolutions": {
-    "brace-expansion": ">=5.0.9",
+    "brace-expansion": ">=5.0.6",
     "tar": ">=7.5.16",
     "undici": ">=6.27.0",
     "js-yaml": ">=4.1.2",


### PR DESCRIPTION
Reverts openfoodfacts/openfoodfacts-js#931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported `brace-expansion` version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->